### PR TITLE
Adding documentation for multiModel in addPlots and plotStudy.

### DIFF
--- a/R/add.R
+++ b/R/add.R
@@ -385,13 +385,6 @@ addMetaFeatures <- function(study, metaFeatures, reset = FALSE) {
 #' Fortunately this latter code will also run fine as you interactively develop
 #' the function.
 #'
-#' You can specify the plotType when you add a plot with \code{\link{addPlots}}.
-#' By default, the app will pass a single featureID unless the plotType is
-#' "multiFeature". Similarly, the app will pass a single testID unless the plotType
-#' is "multiTest". Finally, one or more testIDs can be passed per modelID when
-#' plotType is "multiModel". Note that for plotType = "multiModel", testID must be
-#' provided as a named vector, with each testID named after the related modelID.
-#'
 #' @param plots Custom plotting functions for the study. The input object is a
 #'   nested list. The first list corresponds to the modelID(s). The second list
 #'   corresponds to the name(s) of the function(s) defined in the current R

--- a/R/add.R
+++ b/R/add.R
@@ -385,6 +385,13 @@ addMetaFeatures <- function(study, metaFeatures, reset = FALSE) {
 #' Fortunately this latter code will also run fine as you interactively develop
 #' the function.
 #'
+#' You can specify the plotType when you add a plot with \code{\link{addPlots}}.
+#' By default, the app will pass a single featureID unless the plotType is
+#' "multiFeature". Similarly, the app will pass a single testID unless the plotType
+#' is "multiTest". Finally, one or more testIDs can be passed per modelID when
+#' plotType is "multiModel". Note that for plotType = "multiModel", testID must be
+#' provided as a named vector, with each testID named after the related modelID.
+#'
 #' @param plots Custom plotting functions for the study. The input object is a
 #'   nested list. The first list corresponds to the modelID(s). The second list
 #'   corresponds to the name(s) of the function(s) defined in the current R

--- a/R/plots.R
+++ b/R/plots.R
@@ -8,7 +8,10 @@
 #' the nested list returned by this function is passed as the first argument to
 #' your custom plotting function. By default, the app will pass a single
 #' featureID unless the plotType is "multiFeature". Similarly, the app will pass
-#' a single testID unless the plotType is "multiTest". You can specify the
+#' a single testID unless the plotType is "multiTest". Finally, one or more
+#' testIDs can be passed per modelID when plotType is "multiModel". Note that
+#' for plotType = "multiModel", testID must be provided as a named vector,
+#' with each testID named after the related modelID. You can specify the
 #' plotType when you add a plot with \code{\link{addPlots}}.
 #'
 #' @return This function is called for the side effect of creating a plot. It

--- a/R/plots.R
+++ b/R/plots.R
@@ -6,13 +6,7 @@
 #' @details The arguments \code{study}, \code{modelID}, \code{featureID}, and
 #' \code{testID} are passed to the function \code{\link{getPlottingData}}, and
 #' the nested list returned by this function is passed as the first argument to
-#' your custom plotting function. By default, the app will pass a single
-#' featureID unless the plotType is "multiFeature". Similarly, the app will pass
-#' a single testID unless the plotType is "multiTest". Finally, one or more
-#' testIDs can be passed per modelID when plotType is "multiModel". Note that
-#' for plotType = "multiModel", testID must be provided as a named vector,
-#' with each testID named after the related modelID. You can specify the
-#' plotType when you add a plot with \code{\link{addPlots}}.
+#' your custom plotting function.
 #'
 #' @return This function is called for the side effect of creating a plot. It
 #'   invisibly returns the result from the custom plotting function specified by
@@ -224,6 +218,8 @@ resetSearch <- function(pkgNamespaces) {
 #' This function creates the input data that \code{\link{plotStudy}} passes to
 #' custom plotting functions added with \code{\link{addPlots}}. You can use it
 #' directly when you are interactively creating your custom plotting functions.
+#' Note that for multiModel plots testID is required to be a named vector, with
+#' each testID named after the related modelID.
 #'
 #' @inheritParams shared-get
 #' @inheritParams listStudies

--- a/man/getPlottingData.Rd
+++ b/man/getPlottingData.Rd
@@ -56,6 +56,8 @@ with \code{\link{addPlots}}.
 This function creates the input data that \code{\link{plotStudy}} passes to
 custom plotting functions added with \code{\link{addPlots}}. You can use it
 directly when you are interactively creating your custom plotting functions.
+Note that for multiModel plots testID is required to be a named vector, with
+each testID named after the related modelID.
 }
 \seealso{
 \code{\link{addPlots}}, \code{\link{plotStudy}}

--- a/man/plotStudy.Rd
+++ b/man/plotStudy.Rd
@@ -37,10 +37,7 @@ Plot a feature using a custom plotting function
 The arguments \code{study}, \code{modelID}, \code{featureID}, and
 \code{testID} are passed to the function \code{\link{getPlottingData}}, and
 the nested list returned by this function is passed as the first argument to
-your custom plotting function. By default, the app will pass a single
-featureID unless the plotType is "multiFeature". Similarly, the app will pass
-a single testID unless the plotType is "multiTest". You can specify the
-plotType when you add a plot with \code{\link{addPlots}}.
+your custom plotting function.
 }
 \seealso{
 \code{\link{addPlots}}, \code{\link{getPlottingData}}


### PR DESCRIPTION
- Describe multiModel call via plotType and need of having named vector for testIDs, with each testID named after the corresponding modelID