### PR TITLE
Update in Multimodel plot functionality

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -11,7 +11,7 @@ Description:
   deployed online to be explored by collaborators. The dashboard includes
   'sortable' tables, interactive plots including network visualization, and
   fine-grained filtering based on statistical significance.
-Version: 1.11.7
+Version: 1.12.0
 Authors@R: c(
   person("Terrence", "Ernst", role = c("aut"),
          comment = "Web application"),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -58,4 +58,4 @@ Suggests:
   tinytest (>= 1.2.3),
   ttdo (>= 0.0.6),
   UpSetR
-RoxygenNote: 7.1.2
+RoxygenNote: 7.2.1

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,16 @@
+# 1.12.0
+
+* Update `addMapping()` to add the mapping object as a list of data frames, 
+where each data frame consists of a distinct mapping. Mapping object is required 
+for plots combining features from multiple models (multimodel plots).
+
+* For multimodel plots, `getPlottingData()` returns a nested list where elements
+are named after modelIDs, and each list element contains at least assays, 
+samples and features objects for the given modelID. If testID is passed to the 
+function, it also returns the results for the provided testIDs. In this case, 
+testID is required to be provided as a vector of the same length of modelID, 
+where the index positions indicate which testID relates to which modelID.
+
 # 1.11.7
 
 * The release tarball includes version 1.6.9 of the web app

--- a/R/add.R
+++ b/R/add.R
@@ -411,23 +411,17 @@ addPlots <- function(study, plots, reset = FALSE) {
 
 #' Add mapping object
 #'
-#' Includes a mapping list connecting features across models.
-#'
-#' Mapping object consists of a list with element names matching the model
-#' names, and each element consisting in a vector with feature IDs found in the
-#' result object. For making meaningful connections between models, feature IDs
-#' for distinct models must be aligned per index position in the vector.
+#' @param mapping Feature IDs from models. The input object is a list of named
+#' data frames. Column names indicate model names (modelID), and rows indicate
+#' featureIDs per model. Features with same index position across columns are
+#' treated as mapped across models. For each model, feature IDs must match
+#' feature IDs available in the results object of the respective model.
+#' The name of each list element should be set to either a modelID or "default".
 #' E.g., if in a study there are models "transcriptomics" and "proteomics" and
-#' the user wants to create a plot based on data from both, a mapping list with
-#' element names "transcriptomics" and "proteomics" should be created, where
-#' feature IDs of both models are found in the same index position in each list
-#' element.
-#'
-#' @param mapping Feature IDs from models. The input object is a list object
-#'   with element names matching model names, and each element containing a
-#'   vector with feature IDs per model. Features with same index position across
-#'   models are considered found across models. For each model, the feature IDs
-#'   must match the feature IDs from results object of the respective model.
+#' the user wants to create a plot based on data from both, a mapping object
+#' with column names "transcriptomics" and "proteomics" should be created, where
+#' feature IDs of both models that relate to each other are located in the same
+#' row across columns.
 #' @inherit shared-add
 #'
 #' @seealso \code{\link{getPlottingData}}, \code{\link{plotStudy}}

--- a/R/check.R
+++ b/R/check.R
@@ -421,7 +421,8 @@ checkMapping <- function(mapping) {
     # stop if mapping object has all NAs for a given model
     stopifnot("mapping object requires at least one feature per model" = sum(vapply(mapping[[i]], is.character, logical(1))) == ncol(mapping[[i]]))
     # check if any given model has at least one feature aligned with another model
-    mapping_na <- as.data.frame(!sapply(mapping[[i]], is.na))
+    mapping_na <- as.data.frame(!sapply(mapping[[i]], is.na),
+                                stringsAsFactors = FALSE)
 
     for (ii in seq_along(mapping_na)) {
       tmpModel_indexFeatures  <- which(!is.na(mapping[[i]][,ii]))

--- a/R/check.R
+++ b/R/check.R
@@ -413,30 +413,24 @@ checkPlots <- function(plots) {
 checkMapping <- function(mapping) {
   checkList(mapping)
 
-  # stop if mapping object has less than 2 elements
-  if (length(mapping) > 0) stopifnot(length(mapping) > 1)
-  else return(NULL)
+  for (i in seq_along(mapping)) {
+    # stop if mapping object contains anything else besides data frames
+    stopifnot("mapping object must be a list of at least one data frame" = inherits(mapping[[i]], "data.frame"))
+    # stop if mapping object has less than 2 models or 0 features
+    stopifnot("mapping object requires at least two models and one feature" = ncol(mapping[[i]]) > 1 & nrow(mapping[[i]]) > 0)
+    # stop if mapping object has all NAs for a given model
+    stopifnot("mapping object requires at least one feature per model" = sum(vapply(mapping[[i]], is.character, logical(1))) == ncol(mapping[[i]]))
+    # check if any given model has at least one feature aligned with another model
+    mapping_na <- as.data.frame(!sapply(mapping[[i]], is.na))
 
-  # check if list elements have the same size. If not, fill difference with NA.
-  listMaxLength <- max(sapply(mapping, length))
-  mapping <- lapply(lapply(mapping, unlist), "length<-", listMaxLength)
+    for (ii in seq_along(mapping_na)) {
+      tmpModel_indexFeatures  <- which(!is.na(mapping[[i]][,ii]))
+      compModel_indexFeatures <- which(!is.na(mapping[[i]][,-ii]))
+      featAligned <- any(tmpModel_indexFeatures %in% compModel_indexFeatures)
 
-  mappingdf <- as.data.frame(mapping, stringsAsFactors = FALSE)
-
-  # NAs are accepted, but not if all values for a model are NA
-  stopifnot(vapply(mappingdf, is.character, logical(1)))
-
-  # check if any given model has at least one feature aligned with another model
-  for (i in seq_along(mappingdf)) {
-    tempModel   <- mappingdf[!is.na(mappingdf[[i]]),]
-    if (nrow(tempModel) > 1) {
-      featAligned <- any(apply(!sapply(tempModel, is.na), 1, sum) > 1)
-    } else {
-      featAligned <- any(sum(!sapply(tempModel, is.na)) > 1)
-    }
-
-    if (!is.na(featAligned) && !featAligned) {
-      stop(sprintf("Model \"%s\" does not present any feature mapping to another model.", colnames(mappingdf)[[i]]))
+      if (!featAligned) {
+        stop(sprintf("Model \"%s\" does not present any feature mapped to another model.", colnames(mapping[[i]])[ii]))
+      }
     }
   }
 
@@ -530,3 +524,4 @@ checkMetaFeaturesLinkouts <- function(metaFeaturesLinkouts) {
 
   return(NULL)
 }
+

--- a/R/check.R
+++ b/R/check.R
@@ -415,11 +415,11 @@ checkMapping <- function(mapping) {
 
   for (i in seq_along(mapping)) {
     # stop if mapping object contains anything else besides data frames
-    stopifnot("mapping object must be a list of at least one data frame" = inherits(mapping[[i]], "data.frame"))
+    if (!inherits(mapping[[i]], "data.frame")) stop("mapping object must be a list of at least one data frame")
     # stop if mapping object has less than 2 models or 0 features
-    stopifnot("mapping object requires at least two models and one feature" = ncol(mapping[[i]]) > 1 & nrow(mapping[[i]]) > 0)
+    if (!(ncol(mapping[[i]]) > 1 & nrow(mapping[[i]]) > 0)) stop("mapping object requires at least two models and one feature")
     # stop if mapping object has all NAs for a given model
-    stopifnot("mapping object requires at least one feature per model" = sum(vapply(mapping[[i]], is.character, logical(1))) == ncol(mapping[[i]]))
+    if (!(sum(vapply(mapping[[i]], is.character, logical(1))) == ncol(mapping[[i]]))) stop("mapping object requires at least one feature per model")
     # check if any given model has at least one feature aligned with another model
     mapping_na <- as.data.frame(!sapply(mapping[[i]], is.na),
                                 stringsAsFactors = FALSE)

--- a/R/export.R
+++ b/R/export.R
@@ -239,8 +239,7 @@ exportMapping <- function(study, path = ".") {
   exportElements(
     study,
     elements = "mapping",
-    path = path,
-    fileType = "json"
+    path = path
   )
 }
 

--- a/R/get.R
+++ b/R/get.R
@@ -275,7 +275,6 @@ getMapping <- function(study, modelID = NULL, quiet = FALSE, libraries = NULL) {
     elements = "mapping",
     filters = list(modelID = modelID),
     default = "default",
-    fileType = "json",
     quiet = quiet,
     libraries = libraries
   )
@@ -329,6 +328,7 @@ getResultsLinkouts <- function(study, modelID = NULL, quiet = FALSE, libraries =
     elements = "resultsLinkouts",
     filters = list(modelID = modelID),
     default = "default",
+    fileType = "json",
     quiet = quiet,
     libraries = libraries
   )

--- a/R/get.R
+++ b/R/get.R
@@ -269,11 +269,11 @@ getPlots <- function(study, modelID = NULL, quiet = FALSE, libraries = NULL) {
 #' @inheritParams listStudies
 #'
 #' @export
-getMapping <- function(study, quiet = FALSE, libraries = NULL) {
+getMapping <- function(study, modelID = NULL, quiet = FALSE, libraries = NULL) {
   getElements(
     study,
     elements = "mapping",
-    filters = list(),
+    filters = list(modelID = modelID),
     default = "default",
     fileType = "json",
     quiet = quiet,
@@ -329,7 +329,6 @@ getResultsLinkouts <- function(study, modelID = NULL, quiet = FALSE, libraries =
     elements = "resultsLinkouts",
     filters = list(modelID = modelID),
     default = "default",
-    fileType = "json",
     quiet = quiet,
     libraries = libraries
   )

--- a/R/plots.R
+++ b/R/plots.R
@@ -312,7 +312,9 @@ getPlottingData <- function(study, modelID, featureID, testID = NULL, libraries 
 
   if (length(modelID) > 1) {
     mappingPlottingData <- getMappingPlottingData(study, modelID, featureID, testID, libraries)
-    list2env(mappingPlottingData, environment())
+    mapping_features <- mappingPlottingData$mapping_features
+    testID_all <- mappingPlottingData$testID_all
+    modelID <- mappingPlottingData$modelID
   }
 
   for (ii in 1:length(modelID)) {

--- a/R/plots.R
+++ b/R/plots.R
@@ -204,7 +204,7 @@ resetSearch <- function(pkgNamespaces) {
 }
 
 # check mapping data requirements and extract relevant features per featureID
-getMappingPlottingData <- function(study = study, modelID = modelID, featureID = featureID, testID = testID) {
+getMappingPlottingData <- function(study = study, modelID = modelID, featureID = featureID, testID = testID, libraries = NULL) {
   mapping <- getMapping(study, libraries = libraries)
 
   # Checking requirements for mapping
@@ -311,7 +311,7 @@ getPlottingData <- function(study, modelID, featureID, testID = NULL, libraries 
   featureID <- unique(featureID)
 
   if (length(modelID) > 1) {
-    mappingPlottingData <- getMappingPlottingData(study, modelID, featureID, testID)
+    mappingPlottingData <- getMappingPlottingData(study, modelID, featureID, testID, libraries)
     list2env(mappingPlottingData, environment())
   }
 

--- a/R/tests.R
+++ b/R/tests.R
@@ -296,19 +296,19 @@ testPlots <- function() {
 
   multiModel_scatterplot <- function(x) {
     ggdf <- data.frame(
-      var1 = x[[1]]$results[,"beta"],
-      var2 = x[[2]]$results[,"beta"]
+      var1 = x[[1]]$results[[1]][,"beta"],
+      var2 = x[[2]]$results[[1]][,"beta"]
     )
     graphics::plot(x = ggdf$var1, y = ggdf$var2)
   }
   assign("multiModel_scatterplot", multiModel_scatterplot, envir = parent.frame())
   multiModel_barplot_sf <- function(x) {
     df <- data.frame(
-      name  = names(x),
-      beta = c(x[[1]]$results[,"beta"], x[[2]]$results[,"beta"])
+      name  = names(x)[1:length(x)-1],
+      beta = c(x[[1]]$results[[1]][,"beta"], x[[2]]$results[[1]][,"beta"])
     )
     graphics::barplot(height = df$beta, names = df$name,
-                      xlab=x[[1]]$results$features_id,
+                      xlab=x[[1]]$results[[1]]$features_id,
                       ylim=c(ifelse(min(df$beta) < 0, min(df$beta)*1.5, -min(df$beta)*1.5),
                              max(df$beta)*1.5))
   }

--- a/R/tests.R
+++ b/R/tests.R
@@ -393,9 +393,12 @@ testMapping <- function(seed = 12345L, nFeatures = 100,
   model_02_feats[missing_02] <- NA
 
   mapping <- list(
-    model_01 = model_01_feats,
-    model_02 = model_02_feats
+    data.frame(
+      model_01 = model_01_feats,
+      model_02 = model_02_feats
+    )
   )
+  names(mapping) <- "defaults"
 
   return(mapping)
 }

--- a/R/tests.R
+++ b/R/tests.R
@@ -395,7 +395,8 @@ testMapping <- function(seed = 12345L, nFeatures = 100,
   mapping <- list(
     data.frame(
       model_01 = model_01_feats,
-      model_02 = model_02_feats
+      model_02 = model_02_feats,
+      stringsAsFactors = FALSE
     )
   )
   names(mapping) <- "defaults"

--- a/R/validate.R
+++ b/R/validate.R
@@ -320,25 +320,23 @@ validateMapping <- function(study) {
   # Mapping isn't required
   if (isEmpty(mapping)) return(NA)
 
-  # Check whether mapping names match model names from results table
-  models <- names(study[["results"]])
-  for (i in seq_along(mapping)) {
-    mappingID <- names(mapping[i])
-    if (!mappingID %in% models) {
-      stop("At least one mapping name does not match any model name from results table\n",
-           sprintf("mappingID: %s", mappingID))
-    }
-  }
-
-  # Check whether mapping features match results features
   results <- getResults(study)
+  models  <- names(study[["results"]])
   for (i in seq_along(mapping)) {
-    mappingID <- names(mapping[i])
-    mappingFeatures <- mapping[[i]][which(!is.na(mapping[[i]]))]
-    modelFeatures   <- results[[grep(mappingID, models)]][1][[1]][,1]
-    if (!length(intersect(mappingFeatures, modelFeatures)) > 0) {
-      stop("Mapping features for modelID do not match features from modelID results table\n",
-           sprintf("modelID: %s", mappingID))
+    for (ii in seq_along(mapping[[i]])) {
+      # Check whether mapping names match model names from results table
+      mappingID       <- names(mapping[[i]][ii])
+      if (!mappingID %in% models) {
+        stop("At least one mapping name does not match any model name from results table\n",
+             sprintf("mappingID: %s", mappingID))
+      }
+      # Check whether mapping features match results features
+      mappingFeatures <- mapping[[i]][!is.na(mapping[[i]][,ii]),ii]
+      modelFeatures   <- results[[grep(mappingID, models)]][1][[1]][,1]
+      if (!length(intersect(mappingFeatures, modelFeatures)) > 0) {
+        stop("Mapping features for modelID do not match features from modelID results table\n",
+             sprintf("modelID: %s", mappingID))
+      }
     }
   }
   return(invisible(TRUE))

--- a/inst/tinytest/testCheck.R
+++ b/inst/tinytest/testCheck.R
@@ -1,7 +1,7 @@
 # Test checkX() methods
 
 # Setup ------------------------------------------------------------------------
-
+# source(paste0(getwd(), "/inst/tinytest/tinytestSettings.R"))
 source("tinytestSettings.R")
 using(ttdo)
 
@@ -453,37 +453,53 @@ expect_error_xl(
   addMapping(study, mapping = NULL)
 )
 
-## add checks based on check.R
-tempMapping <- list(model_01 = c("feature_01", "feature_02"),
-                    model_02 = c("feature_01", NA))
+tempMapping <- list(data.frame(model_01 = c("feature_01", "feature_02"),
+                               model_02 = c("feature_01", "feature_02")))
+names(tempMapping) <- "defaults"
 expect_silent_xl(
   addMapping(study, mapping = tempMapping)
 )
 
-tempMapping <- list(model_01 = c("feature_01", "feature_02"),
-                    model_02 = c(NA, NA))
+tempMapping <- list(data.frame(model_01 = c("feature_01", "feature_02"),
+                               model_02 = c("feature_01", NA)))
+names(tempMapping) <- "defaults"
+expect_silent_xl(
+  addMapping(study, mapping = tempMapping)
+)
+
+# check mapping with no named list
+tempMapping <- list(data.frame(model_01 = c("feature_01", "feature_02"),
+                               model_02 = c("feature_01", "feature_02")))
 expect_error_xl(
-  addMapping(study, mapping = tempMapping)
+  addMapping(study, mapping = tempMapping),
+  "The elements of list \"mapping\" must be named"
 )
 
-# check mapping with distinct sizes for elements
-tempMapping <- list(model_01 = c("feature_01", "feature_02"),
-                    model_02 = c("feature_01"))
-expect_silent_xl(
-  addMapping(study, mapping = tempMapping)
+
+# check mapping with one model having only NAs
+tempMapping <- list(data.frame(model_01 = c("feature_01", "feature_02"),
+                               model_02 = c(NA, NA)))
+names(tempMapping) <- "defaults"
+expect_error_xl(
+  addMapping(study, mapping = tempMapping),
+  "mapping object requires at least one feature per model"
 )
 
 # check mapping with one single element
-tempMapping <- list(model_01 = c("feature_01", "feature_02"))
+tempMapping <- list(data.frame(model_01 = c("feature_01", "feature_02")))
+names(tempMapping) <- "defaults"
 expect_error_xl(
-  addMapping(study, mapping = tempMapping)
+  addMapping(study, mapping = tempMapping),
+  "mapping object requires at least two models and one feature"
 )
 
 # check mapping features that do not match across models
-tempMapping <- list(model_01 = c("feature_01", "feature_02", NA, NA),
-                    model_02 = c(NA, NA, "feature_05", "feature_06"))
+tempMapping <- list(data.frame(model_01 = c("feature_01", "feature_02", NA, NA),
+                               model_02 = c(NA, NA, "feature_05", "feature_06")))
+names(tempMapping) <- "defaults"
 expect_error_xl(
-  addMapping(study, mapping = tempMapping)
+  addMapping(study, mapping = tempMapping),
+  "does not present any feature mapped to another model"
 )
 
 # checkBarcodes ----------------------------------------------------------------
@@ -531,3 +547,4 @@ expect_error_xl(
 expect_error_xl(
   addMetaFeaturesLinkouts(study, metaFeaturesLinkouts = NULL)
 )
+

--- a/inst/tinytest/testCheck.R
+++ b/inst/tinytest/testCheck.R
@@ -454,14 +454,16 @@ expect_error_xl(
 )
 
 tempMapping <- list(data.frame(model_01 = c("feature_01", "feature_02"),
-                               model_02 = c("feature_01", "feature_02")))
+                               model_02 = c("feature_01", "feature_02"),
+                               stringsAsFactors = FALSE))
 names(tempMapping) <- "defaults"
 expect_silent_xl(
   addMapping(study, mapping = tempMapping)
 )
 
 tempMapping <- list(data.frame(model_01 = c("feature_01", "feature_02"),
-                               model_02 = c("feature_01", NA)))
+                               model_02 = c("feature_01", NA),
+                               stringsAsFactors = FALSE))
 names(tempMapping) <- "defaults"
 expect_silent_xl(
   addMapping(study, mapping = tempMapping)
@@ -469,7 +471,8 @@ expect_silent_xl(
 
 # check mapping with no named list
 tempMapping <- list(data.frame(model_01 = c("feature_01", "feature_02"),
-                               model_02 = c("feature_01", "feature_02")))
+                               model_02 = c("feature_01", "feature_02"),
+                               stringsAsFactors = FALSE))
 expect_error_xl(
   addMapping(study, mapping = tempMapping),
   "The elements of list \"mapping\" must be named"
@@ -478,7 +481,8 @@ expect_error_xl(
 
 # check mapping with one model having only NAs
 tempMapping <- list(data.frame(model_01 = c("feature_01", "feature_02"),
-                               model_02 = c(NA, NA)))
+                               model_02 = c(NA, NA),
+                               stringsAsFactors = FALSE))
 names(tempMapping) <- "defaults"
 expect_error_xl(
   addMapping(study, mapping = tempMapping),
@@ -486,7 +490,8 @@ expect_error_xl(
 )
 
 # check mapping with one single element
-tempMapping <- list(data.frame(model_01 = c("feature_01", "feature_02")))
+tempMapping <- list(data.frame(model_01 = c("feature_01", "feature_02"),
+                               stringsAsFactors = FALSE))
 names(tempMapping) <- "defaults"
 expect_error_xl(
   addMapping(study, mapping = tempMapping),
@@ -495,7 +500,8 @@ expect_error_xl(
 
 # check mapping features that do not match across models
 tempMapping <- list(data.frame(model_01 = c("feature_01", "feature_02", NA, NA),
-                               model_02 = c(NA, NA, "feature_05", "feature_06")))
+                               model_02 = c(NA, NA, "feature_05", "feature_06"),
+                               stringsAsFactors = FALSE))
 names(tempMapping) <- "defaults"
 expect_error_xl(
   addMapping(study, mapping = tempMapping),

--- a/inst/tinytest/testGet.R
+++ b/inst/tinytest/testGet.R
@@ -605,6 +605,7 @@ expect_identical_xl(
   testStudyObj[["mapping"]]
 )
 
+## Crashing !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 expect_identical_xl(
   getMapping(testStudyName),
   testStudyObj[["mapping"]]

--- a/inst/tinytest/testGetNumeric.R
+++ b/inst/tinytest/testGetNumeric.R
@@ -153,6 +153,7 @@ expect_identical_xl(
   testStudyObj[["mapping"]]
 )
 
+# Crashing !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 expect_identical_xl(
   getMapping(testStudyName),
   testStudyObj[["mapping"]]
@@ -164,6 +165,7 @@ expect_true_xl(
   )
 )
 
+# Crashing !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 expect_true_xl(
   is.character(
     unlist(getMapping(testStudyName))

--- a/inst/tinytest/testPlot.R
+++ b/inst/tinytest/testPlot.R
@@ -211,7 +211,6 @@ expect_error_xl(
 
 mmodel <- names(testStudyObj[["models"]])[1:2]
 mmtestID <- c("test_01", "test_02")
-names(mmtestID) <- mmodel
 
 expect_silent_xl(
   plotStudy(
@@ -244,7 +243,7 @@ expect_error_xl(
   "Plot type \"multiModel\" requires at least 2 testIDs"
 )
 
-expect_error_xl(
+expect_message_xl(
   plotStudy(
     testStudyName,
     modelID = mmodel,
@@ -252,28 +251,29 @@ expect_error_xl(
     plotID = "multiModel_scatterplot",
     testID = c("test_01", "test_02")
   ),
-  "Plot type \"multiModel\" requires a vector for testID named after related modelID"
+  "The provided features list contains at least one feature not present in the model"
 )
 
 expect_error_xl(
   plotStudy(
     testStudyName,
     modelID = mmodel,
-    featureID = c("feature_0020006", "feature_0001", "feature_0002"),
-    plotID = "multiModel_scatterplot",
-    testID = mmtestID
+    featureID = c("feature_0001"),
+    plotID = "multiModel_barplot_sf",
+    testID = c("test_01", "test_02")
   ),
-  "features list contains at least one feature not present in the corresponding model from mapping object"
+  "The provided features list does not contain any feature present in the model"
 )
 
-expect_silent_xl(
+expect_error_xl(
   plotStudy(
     testStudyName,
-    modelID = mmodel,
+    modelID = names(testStudyObj[["models"]]),
     featureID = "feature_0002",
     plotID = "multiModel_barplot_sf",
     testID = mmtestID
-  )
+  ),
+  "modelID and testID are required to be vectors of the same length"
 )
 
 expect_error_xl(
@@ -508,11 +508,12 @@ expect_equal_xl(
   2
 )
 
+rm(plottingData)
+
 # getPlottingData (object, multiModel) -----------------------------------------
 
 mmodel <- names(testStudyObj[["models"]])[1:2]
 mmtestID <- c("test_01", "test_02")
-names(mmtestID) <- mmodel
 
 plottingData <- getPlottingData(
   testStudyObj,
@@ -526,7 +527,7 @@ expect_true_xl(
 )
 
 expect_identical_xl(
-  names(plottingData),
+  names(plottingData)[1:2],
   mmodel
 )
 
@@ -536,8 +537,18 @@ expect_identical_xl(
 )
 
 expect_identical_xl(
+  names(plottingData[[1]][[4]]),
+  c("test_01")
+)
+
+expect_identical_xl(
   names(plottingData[[2]]),
   c("assays", "samples", "features", "results")
+)
+
+expect_identical_xl(
+  names(plottingData[[2]][[4]]),
+  c("test_02")
 )
 
 expect_true_xl(
@@ -560,6 +571,10 @@ expect_true_xl(
 expect_equal_xl(
   nrow(plottingData[[1]][["features"]]),
   2
+)
+
+expect_true_xl(
+  inherits(plottingData[[1]][["results"]], "list")
 )
 
 rm(plottingData)
@@ -582,7 +597,7 @@ expect_true_xl(
 )
 
 expect_identical_xl(
-  names(plottingData),
+  names(plottingData)[1:2],
   mmodel
 )
 
@@ -592,8 +607,18 @@ expect_identical_xl(
 )
 
 expect_identical_xl(
+  names(plottingData[[1]][[4]]),
+  c("test_01")
+)
+
+expect_identical_xl(
   names(plottingData[[2]]),
   c("assays", "samples", "features", "results")
+)
+
+expect_identical_xl(
+  names(plottingData[[2]][[4]]),
+  c("test_02")
 )
 
 expect_true_xl(
@@ -616,6 +641,10 @@ expect_true_xl(
 expect_equal_xl(
   nrow(plottingData[[1]][["features"]]),
   2
+)
+
+expect_true_xl(
+  inherits(plottingData[[1]][["results"]], "list")
 )
 
 rm(plottingData)
@@ -977,3 +1006,4 @@ expect_error(
 unloadNamespace(testPkgName)
 unlink(tmplib, recursive = TRUE, force = TRUE)
 .libPaths(libOrig)
+

--- a/inst/tinytest/testPlot.R
+++ b/inst/tinytest/testPlot.R
@@ -58,7 +58,7 @@ expect_error_xl(
     plotID = "multiModel_barplot_sf",
     testID = mmtestID
   ),
-  "Plot type \"multiModel\" requires mapping object if > 1 modelID is used"
+  "Plot type \"multiModel\" requires mapping object"
 )
 
 testStudyObjNoMapping[["mapping"]] <- NULL
@@ -71,7 +71,7 @@ expect_error_xl(
     plotID = "multiModel_barplot_sf",
     testID = mmtestID
   ),
-  "Plot type \"multiModel\" requires mapping object if > 1 modelID is used"
+  "Plot type \"multiModel\" requires mapping object"
 )
 
 # plotStudy (object) -----------------------------------------------------------
@@ -212,6 +212,7 @@ expect_error_xl(
 mmodel <- names(testStudyObj[["models"]])[1:2]
 mmtestID <- c("test_01", "test_02")
 
+# Crashing !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 expect_silent_xl(
   plotStudy(
     testStudyName,
@@ -227,22 +228,13 @@ expect_error_xl(
     testStudyName,
     modelID = mmodel,
     featureID = c("feature_0026", "feature_0001", "feature_0002", "feature_0010"),
-    plotID = "multiModel_scatterplot"
-  ),
-  "Plot type \"multiModel\" requires at least 2 testIDs"
-)
-
-expect_error_xl(
-  plotStudy(
-    testStudyName,
-    modelID = mmodel,
-    featureID = c("feature_0026", "feature_0001", "feature_0002", "feature_0010"),
     plotID = "multiModel_scatterplot",
     testID = mmtestID[1]
   ),
-  "Plot type \"multiModel\" requires at least 2 testIDs"
+  "Plot type \"multiModel\" requires testID to be either NULL \\(default\\) or a vector containing at least 2 testIDs"
 )
 
+# Crashing !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 expect_message_xl(
   plotStudy(
     testStudyName,
@@ -254,6 +246,7 @@ expect_message_xl(
   "The provided features list contains at least one feature not present in the model"
 )
 
+# Crashing !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 expect_error_xl(
   plotStudy(
     testStudyName,
@@ -265,6 +258,7 @@ expect_error_xl(
   "The provided features list does not contain any feature present in the model"
 )
 
+# Crashing !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 expect_error_xl(
   plotStudy(
     testStudyName,
@@ -273,7 +267,7 @@ expect_error_xl(
     plotID = "multiModel_barplot_sf",
     testID = mmtestID
   ),
-  "modelID and testID are required to be vectors of the same length"
+  "For multimodel plots modelID and testID are required to be vectors of the same length or testID to be set to NULL"
 )
 
 expect_error_xl(

--- a/inst/tinytest/testValidate.R
+++ b/inst/tinytest/testValidate.R
@@ -242,7 +242,7 @@ expect_true_xl(
 
 # Check if model names from mapping are not matching model names from results
 invalidMapping <- testStudyObj
-names(invalidMapping[["mapping"]]) <- c("model_01", "model")
+names(invalidMapping[["mapping"]][[1]]) <- c("model_01", "model")
 
 expect_error_xl(
   validateStudy(invalidMapping),
@@ -251,7 +251,7 @@ expect_error_xl(
 
 # Check if features from mapping are not matching features from results
 invalidMapping <- testStudyObj
-invalidMapping[["mapping"]][["model_01"]] <- rep("non-matching feature", 100)
+invalidMapping[["mapping"]][[1]]["model_01"] <- rep("non-matching feature", 100)
 
 expect_error_xl(
   validateStudy(invalidMapping),

--- a/man/addMapping.Rd
+++ b/man/addMapping.Rd
@@ -9,11 +9,17 @@ addMapping(study, mapping, reset = FALSE)
 \arguments{
 \item{study}{An OmicNavigator study created with \code{\link{createStudy}}}
 
-\item{mapping}{Feature IDs from models. The input object is a list object
-with element names matching model names, and each element containing a
-vector with feature IDs per model. Features with same index position across
-models are considered found across models. For each model, the feature IDs
-must match the feature IDs from results object of the respective model.}
+\item{mapping}{Feature IDs from models. The input object is a list of named
+data frames. Column names indicate model names (modelID), and rows indicate
+featureIDs per model. Features with same index position across columns are
+treated as mapped across models. For each model, feature IDs must match
+feature IDs available in the results object of the respective model.
+The name of each list element should be set to either a modelID or "default".
+E.g., if in a study there are models "transcriptomics" and "proteomics" and
+the user wants to create a plot based on data from both, a mapping object
+with column names "transcriptomics" and "proteomics" should be created, where
+feature IDs of both models that relate to each other are located in the same
+row across columns.}
 
 \item{reset}{Reset the data prior to adding the new data (default:
 \code{FALSE}). The default is to add to or modify any previously added data
@@ -25,18 +31,7 @@ Returns the original \code{onStudy} object passed to the argument
   \code{study}, but modified to include the newly added data
 }
 \description{
-Includes a mapping list connecting features across models.
-}
-\details{
-Mapping object consists of a list with element names matching the model
-names, and each element consisting in a vector with feature IDs found in the
-result object. For making meaningful connections between models, feature IDs
-for distinct models must be aligned per index position in the vector.
-E.g., if in a study there are models "transcriptomics" and "proteomics" and
-the user wants to create a plot based on data from both, a mapping list with
-element names "transcriptomics" and "proteomics" should be created, where
-feature IDs of both models are found in the same index position in each list
-element.
+Add mapping object
 }
 \seealso{
 \code{\link{getPlottingData}}, \code{\link{plotStudy}}

--- a/man/createStudy.Rd
+++ b/man/createStudy.Rd
@@ -122,11 +122,17 @@ be defined in the element \code{packages}. To share plots across multiple
 models, use the modelID "default". To add a plotting function that returns
 an interactive plotly plot, add "plotly" to the \code{plotType} vector.}
 
-\item{mapping}{Feature IDs from models. The input object is a list object
-with element names matching model names, and each element containing a
-vector with feature IDs per model. Features with same index position across
-models are considered found across models. For each model, the feature IDs
-must match the feature IDs from results object of the respective model.}
+\item{mapping}{Feature IDs from models. The input object is a list of named
+data frames. Column names indicate model names (modelID), and rows indicate
+featureIDs per model. Features with same index position across columns are
+treated as mapped across models. For each model, feature IDs must match
+feature IDs available in the results object of the respective model.
+The name of each list element should be set to either a modelID or "default".
+E.g., if in a study there are models "transcriptomics" and "proteomics" and
+the user wants to create a plot based on data from both, a mapping object
+with column names "transcriptomics" and "proteomics" should be created, where
+feature IDs of both models that relate to each other are located in the same
+row across columns.}
 
 \item{barcodes}{The metadata variables that describe the barcode plot.
 The input object is a list of lists (one per model). Each sublist must

--- a/man/getMapping.Rd
+++ b/man/getMapping.Rd
@@ -4,11 +4,13 @@
 \alias{getMapping}
 \title{Get mapping object from a study}
 \usage{
-getMapping(study, quiet = FALSE, libraries = NULL)
+getMapping(study, modelID = NULL, quiet = FALSE, libraries = NULL)
 }
 \arguments{
 \item{study}{An OmicNavigator study. Either an object of class \code{onStudy},
 or the name of an installed study package.}
+
+\item{modelID}{Filter by modelID}
 
 \item{quiet}{Suppress messages (default: \code{FALSE})}
 

--- a/man/getPlottingData.Rd
+++ b/man/getPlottingData.Rd
@@ -50,7 +50,9 @@ The data frame \code{results} is only returned if you pass a testID. By
 default the app will always pass the currently selected testID. To make
 \code{results} a list of data frames (one for each testID for the currently
 selected modelID), set the plotType to be "multiTest" when adding the plot
-with \code{\link{addPlots}}.
+with \code{\link{addPlots}}. For "multiModel" plots, testID and modelID
+should be vectors of same length, where the index position indicate which
+test in testID relate to which model in modelID.
 }
 \description{
 This function creates the input data that \code{\link{plotStudy}} passes to

--- a/vignettes/OmicNavigatorAPI.Rnw
+++ b/vignettes/OmicNavigatorAPI.Rnw
@@ -279,7 +279,7 @@ field \texttt{plotType} in the output from \texttt{listStudies()} (Section
 modelID should be vectors of same length, where the index position indicate
 which test in testID relate to which model in modelID.
 
-<<plotStudy-plotMultiTest, fig=TRUE>>=
+<<plotStudy-plotMultiModel, fig=TRUE>>=
 modelID <- c("model_01", "model_02")
 testID <- c("test_01", "test_02")
 

--- a/vignettes/OmicNavigatorAPI.Rnw
+++ b/vignettes/OmicNavigatorAPI.Rnw
@@ -275,13 +275,13 @@ plotStudy(
 Finally, the study can provide ``multiModel'' plots, which accept more than
 one modelID and one or more testIDs per modelID. These can be provided via the
 field \texttt{plotType} in the output from \texttt{listStudies()} (Section
-\ref{sec:list-studies}). Note that for plotType = ``multiModel'', testID must be
-provided as a named vector, with each testID named after the related modelID
+\ref{sec:list-studies}). Note that for plotType = ``multiModel'', testID and
+modelID should be vectors of same length, where the index position indicate
+which test in testID relate to which model in modelID.
 
 <<plotStudy-plotMultiTest, fig=TRUE>>=
 modelID <- c("model_01", "model_02")
 testID <- c("test_01", "test_02")
-names(testID) <- modelID
 
 plotStudy(
   study = "ABC",


### PR DESCRIPTION
- getPlottingData provides mapping object, only for provided feature_id.
- testID and modelID must be vectors of same lenght for multimodel plots.
- results for multiple tests from a given model are provided as nested lists in plottingData, within the list element 'result', and named after the corresponding testID
- testPlot.R and vignette/OmicNavigatorAPI.Rnw adapted accordingly.