### PR TITLE
Check enrichment numeric

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -58,4 +58,4 @@ Suggests:
   tinytest (>= 1.2.3),
   ttdo (>= 0.0.6),
   UpSetR
-RoxygenNote: 7.2.1
+RoxygenNote: 7.2.3

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -11,7 +11,7 @@ Description:
   deployed online to be explored by collaborators. The dashboard includes
   'sortable' tables, interactive plots including network visualization, and
   fine-grained filtering based on statistical significance.
-Version: 1.13.9
+Version: 1.13.10
 Authors@R: c(
   person("Terrence", "Ernst", role = c("aut"),
          comment = "Web application"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+# 1.13.10
+
+* Update check.R, function checkEnrichments to test if enrichments object have
+columns 'nominal' and 'adjusted' with numeric values (required).  
+
 # 1.13.9
 
 * The release tarball includes version 1.8.1 of the web app

--- a/R/check.R
+++ b/R/check.R
@@ -336,6 +336,12 @@ checkEnrichments <- function(enrichments) {
         stopifnot(inherits(test, "data.frame"))
         stopifnot(c("termID", "description", "nominal", "adjusted")
                   %in% colnames(test))
+        if ("nominal" %in% colnames(test) && !is.numeric(test$nominal)) {
+          stop("Column 'nominal' from enrichments must be numeric")
+        }
+        if ("adjusted" %in% colnames(test) && !is.numeric(test$adjusted)) {
+          stop("Column 'adjusted' from enrichments must be numeric")
+        }
         enrichments[[i]][[j]][[k]] <-
           test[, c("termID", "description", "nominal", "adjusted")]
       }

--- a/inst/tinytest/testCheck.R
+++ b/inst/tinytest/testCheck.R
@@ -392,6 +392,24 @@ expect_error_xl(
   "The enrichments cannot be shared using the modelID \"default\""
 )
 
+enrichment_numTest <- OmicNavigator:::testEnrichments()
+enrichment_numTest$model_01$annotation_01$test_01$nominal <-
+  as.character(enrichment_numTest$model_01$annotation_01$test_01$nominal)
+
+expect_error_xl(
+  addEnrichments(study, enrichments = enrichment_numTest),
+  "Column 'nominal' from enrichments must be numeric"
+)
+
+enrichment_numTest <- OmicNavigator:::testEnrichments()
+enrichment_numTest$model_01$annotation_01$test_01$adjusted <-
+  as.character(enrichment_numTest$model_01$annotation_01$test_01$adjusted)
+
+expect_error_xl(
+  addEnrichments(study, enrichments = enrichment_numTest),
+  "Column 'adjusted' from enrichments must be numeric"
+)
+
 # checkMetaFeatures ------------------------------------------------------------
 
 expect_error_xl(


### PR DESCRIPTION
Provides checks to test if 'nominal' and 'adjusted' columns for Enrichment tables are numeric. Also includes checks in tinytest file (testCheck.R)