### PR TITLE
Bump Ubuntu CI job to R 3.6.3

### DIFF
--- a/.github/workflows/comprehensive.yml
+++ b/.github/workflows/comprehensive.yml
@@ -43,7 +43,7 @@ jobs:
         config:
           - {os: windows-latest, r: 'release'}
           - {os: macOS-latest, r: 'release'}
-          - {os: ubuntu-20.04, r: '3.5.3'}
+          - {os: ubuntu-20.04, r: '3.6.3'}
     steps:
       - uses: actions/checkout@v3
       - uses: r-lib/actions/setup-r@v2-branch

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -8,7 +8,7 @@
 * GitHub Actions
     * windows-latest (release)
     * macOS-latest (release)
-    * ubuntu-20.04 (3.5.3)
+    * ubuntu-20.04 (3.6.3)
 
 ## R CMD check results
 


### PR DESCRIPTION
The Ubuntu CI job is [failing](https://github.com/abbvie-external/OmicNavigator/actions/runs/7253464122/job/19760111707#step:6:141) because some of the package dependencies can no longer be installed on R 3.5.3. I bumped it to R 3.6.3, which is the [final patch release](https://cran.r-project.org/bin/windows/base/old/) of the 3.6 series

```
  ! Could not solve package dependencies:
  * deps::.:
    * Can't install dependency faviconPlease
    * Can't install dependency ggplot2
    * Can't install dependency plotly
    * Can't install dependency UpSetR
  * UpSetR: Can't install dependency scales
  * scales: Needs R >= 3.6
  * faviconPlease: Can't install dependency xml2
  * xml2: Needs R >= 3.6.0
  * ggplot2:
    * Can't install dependency lifecycle (> 1.0.1) (>= 1.2.0)
    * Can't install dependency scales (>= 1.2.0)
  * lifecycle: Needs R >= 3.6
  * plotly: Can't install dependency scales
  * any::sessioninfo: dependency conflict
```
