### PR TITLE
Remove deployment-related files from R package tarball

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -19,3 +19,5 @@
 ^vignettes/.*\.synctex\.gz$
 ^vignettes/.*\.tex$
 ^vignettes/.*\.toc$
+^Deployment\.md$
+^DockerDeploy$


### PR DESCRIPTION
This fixes the following `NOTE` from `R CMD check`:

```R
* checking top-level files ... NOTE
Non-standard files/directories found at top level:
  'Deployment.md' 'DockerDeploy'
```

https://github.com/abbvie-external/OmicNavigator/actions/runs/7448693247/job/20263624349#step:8:45