### PR TITLE
Migrate (some) Actions to Node 20

### DIFF
--- a/.github/workflows/comprehensive.yml
+++ b/.github/workflows/comprehensive.yml
@@ -45,7 +45,7 @@ jobs:
           - {os: macOS-latest, r: 'release'}
           - {os: ubuntu-20.04, r: '3.6.3'}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: r-lib/actions/setup-r@v2-branch
         with:
           r-version: ${{ matrix.config.r }}
@@ -76,7 +76,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Deploy main dispatch
-        uses: peter-evans/repository-dispatch@v1
+        uses: peter-evans/repository-dispatch@v3
         with:
           token: ${{ secrets.REPO_ACCESS_TOKEN }}
           repository: abbvie-internal/OmicNavigatorCD

--- a/.github/workflows/pin-app.yml
+++ b/.github/workflows/pin-app.yml
@@ -14,7 +14,7 @@ jobs:
   dev:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           token: ${{ secrets.REPO_ACCESS_TOKEN }}
 

--- a/.github/workflows/quick.yml
+++ b/.github/workflows/quick.yml
@@ -22,7 +22,7 @@ jobs:
   quick:
     runs-on: ubuntu-22.04
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Setup r2u
       run: sudo bash scripts/setup-r2u.sh
     - name: Install R packages
@@ -57,7 +57,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Deploy dev dispatch
-        uses: peter-evans/repository-dispatch@v1
+        uses: peter-evans/repository-dispatch@v3
         with:
           token: ${{ secrets.REPO_ACCESS_TOKEN }}
           repository: abbvie-internal/OmicNavigatorCD

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
     - name: Extract package version from tag reference
       run: echo "version=${GITHUB_REF#refs/tags/v}" >> $GITHUB_ENV
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Setup r2u
       run: sudo bash scripts/setup-r2u.sh
     - name: Install R packages
@@ -104,7 +104,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Deploy release dispatch
-        uses: peter-evans/repository-dispatch@v1
+        uses: peter-evans/repository-dispatch@v3
         with:
           token: ${{ secrets.REPO_ACCESS_TOKEN }}
           repository: abbvie-internal/OmicNavigatorCD


### PR DESCRIPTION
GitHub will soon require that all Actions run with Node 20

xref: companion to https://github.com/abbvie-external/OmicNavigatorWebApp/pull/133

For actions that have already released a Node 20 compatible version, I've updated them

https://github.com/peter-evans/repository-dispatch/releases/tag/v3.0.0
https://github.com/actions/checkout/releases/tag/v4.0.0

Unfortunately the actions `actions/create-release` and `actions/upload-release-asset` have been archived for years, and thus won't be migrated to Node 20. Annoyingly only 3rd party actions are now available for these core GitHub functions, and thus they would need to be evaluated. Honestly it'd probably just be easier (and more secure) to use the [gh-cli](https://cli.github.com) directly in the workflow.

However, these old actions have actually been getting warnings for a long time, since they are [Node 12 actions being forced to run on Node 16](https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/). Thus I assume they are very simple, and may continue to run on Node 20 as well. Until they actually fail, I recommend we just leave them as is.

