### PR TITLE
Ipad 508 enable model designation for multimodel plots

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -11,7 +11,7 @@ Description:
   deployed online to be explored by collaborators. The dashboard includes
   'sortable' tables, interactive plots including network visualization, and
   fine-grained filtering based on statistical significance.
-Version: 1.13.19
+Version: 1.13.20
 Authors@R: c(
   person("Terrence", "Ernst", role = c("aut"),
          comment = "Web application"),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -11,7 +11,7 @@ Description:
   deployed online to be explored by collaborators. The dashboard includes
   'sortable' tables, interactive plots including network visualization, and
   fine-grained filtering based on statistical significance.
-Version: 1.13.18
+Version: 1.13.19
 Authors@R: c(
   person("Terrence", "Ernst", role = c("aut"),
          comment = "Web application"),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -11,7 +11,7 @@ Description:
   deployed online to be explored by collaborators. The dashboard includes
   'sortable' tables, interactive plots including network visualization, and
   fine-grained filtering based on statistical significance.
-Version: 1.13.17
+Version: 1.13.18
 Authors@R: c(
   person("Terrence", "Ernst", role = c("aut"),
          comment = "Web application"),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -11,7 +11,7 @@ Description:
   deployed online to be explored by collaborators. The dashboard includes
   'sortable' tables, interactive plots including network visualization, and
   fine-grained filtering based on statistical significance.
-Version: 1.13.16
+Version: 1.13.17
 Authors@R: c(
   person("Terrence", "Ernst", role = c("aut"),
          comment = "Web application"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# 1.13.17
+
+* The release tarball includes version 1.9.0 of the web app
+
 * Update `getBarcodeData()` to pass lowest statistic value. Change enables barcode plot to accommodate negative numbers.
 
 # 1.13.16

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# 1.13.20
+
+* The release tarball includes version 1.9.3 of the web app
+
 * Fix bug in `importStudy()` that resulted in mapping table not being imported.
 
 # 1.13.19

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# 1.13.18
+
+* The release tarball includes version 1.9.1 of the web app
+
 # 1.13.17
 
 * The release tarball includes version 1.9.0 of the web app

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,5 @@
+* Fix bug in `importStudy()` that resulted in mapping table not being imported.
+
 # 1.13.19
 
 * The release tarball includes version 1.9.2 of the web app

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# 1.13.19
+
+* The release tarball includes version 1.9.2 of the web app
+
 # 1.13.18
 
 * The release tarball includes version 1.9.1 of the web app

--- a/R/check.R
+++ b/R/check.R
@@ -410,6 +410,17 @@ checkPlots <- function(plots) {
       if (is.null(plotEntry[["displayName"]])) {
         stop(sprintf("Must define displayName for plot \"%s\"", plotID))
       }
+      # For multiModel plots, check if field 'models' is available and, if so,
+      # check if models != 'all' is associated with plotType multiModel
+      if (!is.null(plotEntry[["models"]])) {
+        models <- plotEntry[["models"]]
+        if ((length(models) > 1 || models != 'all') && !any(plotEntry[["plotType"]] %in% "multiModel")) {
+          stop(
+            sprintf("For field models != 'all' plotType field requires 'multiModel'.\n"),
+            sprintf("The custom plot \"%s\" has models \"%s\" and plotType \"%s\".", plotID, paste(c(models), collapse=', '), paste(c(plotEntry[["plotType"]]), collapse=', '))
+          )
+        }
+      }
     }
   }
 

--- a/R/import.R
+++ b/R/import.R
@@ -72,6 +72,7 @@ importStudy <- function(study, libraries = NULL) {
     plots = getPlots(study, quiet = TRUE, libraries = libraries),
     barcodes = getBarcodes(study, quiet = TRUE, libraries = libraries),
     reports = reports,
+    mapping = getMapping(study, quiet = TRUE, libraries = libraries),
     resultsLinkouts = getResultsLinkouts(study, quiet = TRUE, libraries = libraries),
     enrichmentsLinkouts = getEnrichmentsLinkouts(study, quiet = TRUE, libraries = libraries),
     metaFeaturesLinkouts = getMetaFeaturesLinkouts(study, quiet = TRUE, libraries = libraries),

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -10,7 +10,7 @@ OmicNavigatorPrefix <- "ONstudy"
 
 # The R package is meant to be used with a specific version of the app. If a
 # user has an older or newer version installed, send a warning.
-versionAppPinned <- "1.8.9"
+versionAppPinned <- "1.9.0"
 
 # The extra packages required to run the app
 appPackages <- c(

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -10,7 +10,7 @@ OmicNavigatorPrefix <- "ONstudy"
 
 # The R package is meant to be used with a specific version of the app. If a
 # user has an older or newer version installed, send a warning.
-versionAppPinned <- "1.9.0"
+versionAppPinned <- "1.9.1"
 
 # The extra packages required to run the app
 appPackages <- c(

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -10,7 +10,7 @@ OmicNavigatorPrefix <- "ONstudy"
 
 # The R package is meant to be used with a specific version of the app. If a
 # user has an older or newer version installed, send a warning.
-versionAppPinned <- "1.9.1"
+versionAppPinned <- "1.9.2"
 
 # The extra packages required to run the app
 appPackages <- c(

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -10,7 +10,7 @@ OmicNavigatorPrefix <- "ONstudy"
 
 # The R package is meant to be used with a specific version of the app. If a
 # user has an older or newer version installed, send a warning.
-versionAppPinned <- "1.9.2"
+versionAppPinned <- "1.9.3"
 
 # The extra packages required to run the app
 appPackages <- c(


### PR DESCRIPTION
Create validation tests to verify models field, part of the plots object used in addPlots, match requirements. 
Essentially, "all" is the models default. If models != 'all', then plotType must contain 'multiModel' (checks.R)
Also, if models != 'all', models must contain model names as found in column names from mapping object. First, it searches for mapping object with the same name as the modelname found in the plots object (added to addPlots), if not found, it takes mapping object named as 'default'. 