### PR TITLE
Update CRAN submission instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -336,3 +336,7 @@ locally), and [submit the tarball][cran].
 rm -r inst/www/
 R CMD build .
 ```
+
+Enter the name and email of the current package maintainer (role `cre` in
+`DESCRIPTION`). Copy-paste the contents of `cran-comments.md` into the box
+"Optional comment". Finally click "Upload the package".

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -13,10 +13,3 @@
 ## R CMD check results
 
 0 errors | 0 warnings | 0 notes
-
-## Comments
-
-* Added the appropriate PKGNAME-package \alias to the package overview help file
-  as per "Documenting packages" in R-exts
-
-* Updated invalid URLs


### PR DESCRIPTION
I added some additional instructions for the CRAN submission process.

Also, I realized that I am still the maintainer of this package. I think we should update this. To do this, we would need to move the role `"cre"` from me to another package author (and that author has to provide an email). Then we would submit to CRAN, and I would be sent an email to approve the change of maintainer.