### PR TITLE
Update minimum R version for regular testing to 4.0.5

### DIFF
--- a/.github/workflows/comprehensive.yml
+++ b/.github/workflows/comprehensive.yml
@@ -43,7 +43,7 @@ jobs:
         config:
           - {os: windows-latest, r: 'release'}
           - {os: macOS-latest, r: 'release'}
-          - {os: ubuntu-20.04, r: '3.6.3'}
+          - {os: ubuntu-20.04, r: '4.0.5'}
     steps:
       - uses: actions/checkout@v4
       - uses: r-lib/actions/setup-r@v2-branch

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -8,7 +8,7 @@
 * GitHub Actions
     * windows-latest (release)
     * macOS-latest (release)
-    * ubuntu-20.04 (3.6.3)
+    * ubuntu-20.04 (4.0.5)
 
 ## R CMD check results
 


### PR DESCRIPTION
The current Ubuntu CI is [failing](https://github.com/abbvie-external/OmicNavigator/actions/runs/9664546498/job/26659429813#step:6:141) with R 3.6.3 because {evalulate} requires R >= 4.0.0

```
  Error: 
  ! error in pak subprocess
  Caused by error: 
  ! Could not solve package dependencies:
  * deps::.: Can't install dependency opencpu
  * opencpu: Can't install dependency evaluate (>= 0.12)
  * evaluate: Needs R >= 4.0.0
  * any::sessioninfo: dependency conflict
```

Thus we need to update the minimum R version that we regularly test against. I first tried R 4.0.0, but that [failed](https://github.com/jdblischak/OmicNavigator/actions/runs/9666511617/job/26666182555#step:8:111) because some of our plotting tests require no output, and using R 4.0.0 when the installed packages were built with R 4.0.5 leads to warnings such as `package 'data.table' was built under R version 4.0.5`. So I updated to 4.0.5, and it [passed](https://github.com/jdblischak/OmicNavigator/actions/runs/9666677750)

cc: @bengalengel 