### PR TITLE
IPAD-512

### DIFF
--- a/R/plots.R
+++ b/R/plots.R
@@ -246,13 +246,22 @@ getMappingPlottingData <- function(study = study, modelID = modelID, featureID =
     )
   }
   if (!all(featureID %in% model_features)) {
-    message(
+    stop(
       sprintf(
         "The provided features list contains at least one feature not present in model '%s' from mapping object.",
         modelID[1]
-      ),
+      )
+    )
+  }
+
+  secondary_mapping  <- mapping[which(mapping[, modelID[1]] %in% featureID), ]
+  secondary_mapping[, modelID[1]]  <- NULL
+  secondary_features <- data.frame(secondary_mapping[rowSums(is.na(secondary_mapping)) != ncol(secondary_mapping),])
+  if (nrow(secondary_features) == 0) {
+    stop(
       sprintf(
-        "\nOnly features available in the mapping object will be shown."
+        "The selected features list contains features available in the selected model '%s' only.",
+        modelID[1]
       )
     )
   }
@@ -269,7 +278,7 @@ getMappingPlottingData <- function(study = study, modelID = modelID, featureID =
   for (ii in colnames(mapping)) {
     if (ii == modelID[1]) next
     if (any(is.na(mapping[ii]))) {
-      message(
+      warning(
         sprintf("At least one feature from model '%s' is not available in other model(s): e.g., '%s'.",
                 modelID[1], model_features[which(is.na(mapping[ii]))[1]])
       )

--- a/R/plots.R
+++ b/R/plots.R
@@ -265,6 +265,17 @@ getMappingPlottingData <- function(study = study, modelID = modelID, featureID =
       sprintf("testID: %s", paste(testID, collapse = ", "))
     )
   }
+  # Inform user if at least one feature from modelID is not present in secondary models
+  for (ii in colnames(mapping)) {
+    if (ii == modelID[1]) next
+    if (any(is.na(mapping[ii]))) {
+      message(
+        sprintf("At least one feature from model '%s' is not available in other model(s): e.g., '%s'.",
+                modelID[1], model_features[which(is.na(mapping[ii]))[1]])
+      )
+      break
+    }
+  }
 
   # Structuring data for mapping
   mappingdf <- as.data.frame(mapping, stringsAsFactors = FALSE)
@@ -385,10 +396,31 @@ getPlottingData <- function(study, modelID, featureID, testID = NULL, libraries 
       stop(sprintf("No assays available for modelID \"%s\"\n", model_i),
            "Add assays data with addAssays()")
     } else {
-      featureIDAvailable <- featureID %in% rownames(assays)
-      if (any(!featureIDAvailable)) {
-        stop(sprintf("The feature \"%s\" is not available for modelID \"%s\"",
-                     featureID[!featureIDAvailable][1], model_i))
+      # only necessary for singleModel plots - for multiModel the check is done at getMappingPlottingData
+      if (length(modelID) == 1) {
+        if (!is.null(testID)) {
+          featID_tmp <- NULL
+          for (i_testID in testID) {
+            tmp <- getResults(study, modelID = model_i, testID = i_testID, quiet = TRUE,
+                              libraries = libraries)
+            if (is.data.frame(tmp)) {
+              featID_tmp <- unique(c(featID_tmp, tmp[[1]]))
+            }
+          }
+          # featureIDAvailable <- featureID %in% unique(as.vector(as.matrix(sapply(study$results[[model_i]], function(x) x[[1]]))))
+          featureIDAvailable <- featureID %in% featID_tmp
+          if (any(!featureIDAvailable)) {
+            stop(sprintf("At least one feature is not available in the results object for modelID \"%s\": \"%s\"",
+                         model_i, featureID[!featureIDAvailable][1]))
+          }
+        }
+        if (is.null(testID) || (!is.null(testID) && !is.data.frame(tmp))) {
+          featureIDAvailable <- featureID %in% rownames(assays)
+          if (any(!featureIDAvailable)) {
+            stop(sprintf("At least one feature is not available in the assay object for modelID \"%s\": \"%s\"",
+                         model_i, featureID[!featureIDAvailable][1]))
+          }
+        }
       }
       assaysPlotting <- assays[featureID, , drop = FALSE]
     }

--- a/R/plots.R
+++ b/R/plots.R
@@ -248,7 +248,7 @@ getMappingPlottingData <- function(study = study, modelID = modelID, featureID =
   if (!all(featureID %in% model_features)) {
     stop(
       sprintf(
-        "The provided features list contains at least one feature not present in model '%s' from mapping object.",
+        "At least one feature is not present in the first model passed, '%s'.",
         modelID[1]
       )
     )
@@ -260,7 +260,7 @@ getMappingPlottingData <- function(study = study, modelID = modelID, featureID =
   if (nrow(secondary_features) == 0) {
     stop(
       sprintf(
-        "The selected features list contains features available in the selected model '%s' only.",
+        "The features are only present in the first model passed, '%s'.",
         modelID[1]
       )
     )
@@ -275,15 +275,20 @@ getMappingPlottingData <- function(study = study, modelID = modelID, featureID =
     )
   }
   # Inform user if at least one feature from modelID is not present in secondary models
+  incomplete_matches_sec_models = NULL
   for (ii in colnames(mapping)) {
     if (ii == modelID[1]) next
     if (any(is.na(mapping[ii]))) {
-      warning(
-        sprintf("At least one feature from model '%s' is not available in other model(s): e.g., '%s'.",
-                modelID[1], model_features[which(is.na(mapping[ii]))[1]])
-      )
-      break
+      incomplete_matches_sec_models <- trimws(paste(incomplete_matches_sec_models, ii, collapse=' '))
     }
+  }
+  if (!is.null(incomplete_matches_sec_models)) {
+    warning(
+      sprintf("At least one feature from model '%s' is not mapped in other model(s). Model(s) impacted: %s",
+              modelID[1],
+              incomplete_matches_sec_models
+              )
+    )
   }
 
   # Structuring data for mapping
@@ -416,7 +421,6 @@ getPlottingData <- function(study, modelID, featureID, testID = NULL, libraries 
               featID_tmp <- unique(c(featID_tmp, tmp[[1]]))
             }
           }
-          # featureIDAvailable <- featureID %in% unique(as.vector(as.matrix(sapply(study$results[[model_i]], function(x) x[[1]]))))
           featureIDAvailable <- featureID %in% featID_tmp
           if (any(!featureIDAvailable)) {
             stop(sprintf("At least one feature is not available in the results object for modelID \"%s\": \"%s\"",

--- a/inst/tinytest/testPlot.R
+++ b/inst/tinytest/testPlot.R
@@ -287,7 +287,7 @@ expect_silent_xl(
 expect_error_xl(
   plotStudy(testStudyName, modelID = "model_01", featureID = "feature_0001",
             plotID = "plotBase", testID = "non-existent"),
-  "non-existent"
+  "one feature is not available in the results object for model"
 )
 
 expect_error_xl(

--- a/inst/tinytest/testPlot.R
+++ b/inst/tinytest/testPlot.R
@@ -212,7 +212,7 @@ expect_error_xl(
 mmodel <- names(testStudyObj[["models"]])[1:2]
 mmtestID <- c("test_01", "test_02")
 
-expect_silent_xl(
+expect_warning_xl(
   plotStudy(
     testStudyName,
     modelID = mmodel,
@@ -233,7 +233,7 @@ expect_error_xl(
   "Plot type \"multiModel\" requires testID to be either NULL \\(default\\) or a vector containing at least 2 testIDs"
 )
 
-expect_message_xl(
+expect_error_xl(
   plotStudy(
     testStudyName,
     modelID = mmodel,

--- a/inst/tinytest/testPlot.R
+++ b/inst/tinytest/testPlot.R
@@ -241,7 +241,7 @@ expect_error_xl(
     plotID = "multiModel_scatterplot",
     testID = c("test_01", "test_02")
   ),
-  "The provided features list contains at least one feature not present in model"
+  "At least one feature is not present in the first model passed"
 )
 
 expect_error_xl(
@@ -505,12 +505,12 @@ rm(plottingData)
 mmodel <- names(testStudyObj[["models"]])[1:2]
 mmtestID <- c("test_01", "test_02")
 
-plottingData <- getPlottingData(
+suppressWarnings(plottingData <- getPlottingData(
   testStudyObj,
   modelID = mmodel,
   featureID = c("feature_0010", "feature_0020"),
   testID = mmtestID
-)
+))
 
 expect_true_xl(
   inherits(plottingData, "list")
@@ -575,12 +575,12 @@ mmodel <- names(testStudyObj[["models"]])[1:2]
 mmtestID <- c("test_01", "test_02")
 names(mmtestID) <- mmodel
 
-plottingData <- getPlottingData(
+suppressWarnings(plottingData <- getPlottingData(
   testStudyName,
   modelID = mmodel,
   featureID = c("feature_0010", "feature_0020"),
   testID = mmtestID
-)
+))
 
 expect_true_xl(
   inherits(plottingData, "list")


### PR DESCRIPTION
Changes include: (1) error message if features list provided to plotStudy or getPlottingData contains at least one feature not available in either (a) mapping obj, column modelID[1] for multimodel plots, (b) union of result objects for single model plots, or (c) assay object in case study has no results for single model plots; and (2) a warning message for multimodel plots informing user that at least one feature from modelID[1] is not available in secondary models; and (3) an error message for multimodel plots indicating that selected features are available only in model[1] and not available in any of secondary models.  