### PR TITLE
Migrate comprehensive workflow to ubuntu-22.04

### DIFF
--- a/.github/workflows/comprehensive.yml
+++ b/.github/workflows/comprehensive.yml
@@ -43,9 +43,14 @@ jobs:
         config:
           - {os: windows-latest, r: 'release'}
           - {os: macOS-latest, r: 'release'}
-          - {os: ubuntu-20.04, r: '4.0.5'}
+          - {os: ubuntu-22.04, r: '4.0.5'}
     steps:
       - uses: actions/checkout@v4
+      - name: Install dependencies from PPM snapshot for Ubuntu build
+        if: runner.os == 'Linux'
+        run: |
+          echo "CRAN=https://packagemanager.posit.co/cran/__linux__/jammy/2021-12-29" >> $GITHUB_ENV
+          echo "RSPM=https://packagemanager.posit.co/cran/__linux__/jammy/2021-12-29" >> $GITHUB_ENV
       - uses: r-lib/actions/setup-r@v2-branch
         with:
           r-version: ${{ matrix.config.r }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -213,7 +213,7 @@ the "main" branch.
 
 If you wish to skip all automated CI, e.g. you are trying something experimental
 that you know will break the tests, you can put "skip" anywhere in the branch
-name. Also note that the continuous integrations jobs are only triggered if a
+name. Also note that the continuous integration jobs are only triggered if a
 file that affects the behavior of the package has been modified. For example, if
 you only edit documentation files like `README.md`, the tests won't be run.
 

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -8,7 +8,7 @@
 * GitHub Actions
     * windows-latest (release)
     * macOS-latest (release)
-    * ubuntu-20.04 (4.0.5)
+    * ubuntu-22.04 (4.0.5)
 
 ## R CMD check results
 


### PR DESCRIPTION
The GitHub Actions runner image ubuntu-20.04 was shutdown in [April 2025](https://github.blog/changelog/2025-01-15-github-actions-ubuntu-20-runner-image-brownout-dates-and-other-breaking-changes/).

The only tricky part for migrating to ubuntu-22.04 was continuing to support the older [R 4.0.5](https://cran.r-project.org/bin/windows/base/old/) released in 2021. I was able to continue installing the dependencies by using a Posit Package Manager snapshot from [2021-12-29](https://packagemanager.posit.co/client/#/repos/cran/setup?distribution=ubuntu-22.04&snapshot=2021-12-29&r_environment=other). Conveniently PPM provides pre-built linux binaries even for this older date, so the package installation step is still fast.

