### PR TITLE
Bugfix/description encoding

### DIFF
--- a/R/export.R
+++ b/R/export.R
@@ -426,6 +426,7 @@ createPackage <- function(study, directoryname) {
     Maintainer = pkgmaintainer,
     Description = pkgdescription,
     OmicNavigatorVersion = utils::packageVersion("OmicNavigator"),
+    Encoding = "UTF-8",
     stringsAsFactors = FALSE
   )
   if (!isEmpty(study[["studyMeta"]])) {

--- a/inst/tinytest/testApp.R
+++ b/inst/tinytest/testApp.R
@@ -84,7 +84,7 @@ expect_identical_xl(
 )
 
 expect_identical_xl(
-  c("Package", "Title", "Version", "Maintainer", "Description", "OmicNavigatorVersion",
+  c("Package", "Title", "Version", "Maintainer", "Description", "OmicNavigatorVersion", "Encoding",
     names(OmicNavigator:::testStudyMeta()), "Imports", "Built", "description"),
   names(studies[[1]][["package"]]),
   info = "listStudies() returns DESCRIPTION"

--- a/inst/tinytest/testExport.R
+++ b/inst/tinytest/testExport.R
@@ -8,7 +8,7 @@ using(ttdo)
 library(OmicNavigator)
 
 testStudyName <- "ABC"
-testStudyObj <- OmicNavigator:::testStudy(name = testStudyName)
+testStudyObj <- OmicNavigator:::testStudy(name = testStudyName, description = "Test encoding: β‐catenin and neural cell adhesion molecule (NCAM)")
 testStudyObj <- addPlots(testStudyObj, OmicNavigator:::testPlots())
 minimalStudyObj <- OmicNavigator:::testStudyMinimal()
 minimalStudyName <- minimalStudyObj[["name"]]

--- a/inst/tinytest/testExport.R
+++ b/inst/tinytest/testExport.R
@@ -136,12 +136,12 @@ expect_identical_xl(
   testStudyObj[["name"]]
 )
 
-expect_identical_xl(
-  studyMetadata[[1]][["package"]][["Description"]],
-  sprintf("The OmicNavigator data package for the study \"%s\"",
-          testStudyObj[["description"]]),
-  info = "Default package description when description==name"
-)
+# expect_identical_xl(
+#   studyMetadata[[1]][["package"]][["Description"]],
+#   sprintf("The OmicNavigator data package for the study \"%s\"",
+#           testStudyObj[["description"]]),
+#   info = "Default package description when description==name"
+# )
 
 expect_identical_xl(
   studyMetadata[[1]][["package"]][["Version"]],

--- a/inst/tinytest/testExport.R
+++ b/inst/tinytest/testExport.R
@@ -8,7 +8,7 @@ using(ttdo)
 library(OmicNavigator)
 
 testStudyName <- "ABC"
-testStudyObj <- OmicNavigator:::testStudy(name = testStudyName, description = "Test encoding: β‐catenin and neural cell adhesion molecule (NCAM)")
+testStudyObj <- OmicNavigator:::testStudy(name = testStudyName)
 testStudyObj <- addPlots(testStudyObj, OmicNavigator:::testPlots())
 minimalStudyObj <- OmicNavigator:::testStudyMinimal()
 minimalStudyName <- minimalStudyObj[["name"]]
@@ -19,6 +19,18 @@ tmplibSpace <- file.path(tempdir(), "a space")
 dir.create(tmplibSpace)
 tmplibQuote <- file.path(tempdir(), "project's results")
 dir.create(tmplibQuote)
+
+# Export with special encoding description ------------------------------------
+
+testStudyObj2 <- OmicNavigator:::testStudy(name = testStudyName, description = "Test encoding: β‐catenin and neural cell adhesion molecule (NCAM)")
+testStudyObj2 <- addPlots(testStudyObj2, OmicNavigator:::testPlots())
+minimalStudyObj2 <- OmicNavigator:::testStudyMinimal()
+minimalStudyName2 <- minimalStudyObj2[["name"]]
+
+observed <- exportStudy(testStudyObj2, type = "package", path = tmplib)
+expected <- file.path(tmplib, OmicNavigator:::studyToPkg(testStudyName))
+expect_identical_xl(observed, expected, info = "Export as package directory")
+expect_true_xl(dir.exists(expected))
 
 # Export as package directory --------------------------------------------------
 
@@ -136,12 +148,12 @@ expect_identical_xl(
   testStudyObj[["name"]]
 )
 
-# expect_identical_xl(
-#   studyMetadata[[1]][["package"]][["Description"]],
-#   sprintf("The OmicNavigator data package for the study \"%s\"",
-#           testStudyObj[["description"]]),
-#   info = "Default package description when description==name"
-# )
+expect_identical_xl(
+  studyMetadata[[1]][["package"]][["Description"]],
+  sprintf("The OmicNavigator data package for the study \"%s\"",
+          testStudyObj[["description"]]),
+  info = "Default package description when description==name"
+)
 
 expect_identical_xl(
   studyMetadata[[1]][["package"]][["Version"]],


### PR DESCRIPTION
Per user feedback. Found description where beta character broke exportStudy. Added UTF-8 encoding to prevent other special character issues. 