### PR TITLE
Fix missing Rd link WARNING for RNA-seq 1-2-3 reference

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -58,5 +58,5 @@ Suggests:
   tinytest (>= 1.2.3),
   ttdo (>= 0.0.6),
   UpSetR
-RoxygenNote: 7.3.1
+RoxygenNote: 7.3.2
 Roxygen: list(markdown = TRUE)

--- a/R/data.R
+++ b/R/data.R
@@ -13,7 +13,7 @@
 #'
 #' @references
 #'   Law CW, Alhamdoosh M, Su S, Dong X, Tian L, Smyth GK, Ritchie ME.
-#'   \href{https://f1000research.com/articles/5-1408/v3}{RNA-seq analysis is easy as 1-2-3 with limma, Glimma and edgeR [version 3; peer review: 3 approved].}
+#'   \href{https://f1000research.com/articles/5-1408/v3}{RNA-seq analysis is easy as 1-2-3 with limma, Glimma and edgeR \[version 3; peer review: 3 approved\].}
 #'   F1000Research 2018, 5:1408
 #'   \doi{10.12688/f1000research.9005.3}
 #'

--- a/man/Mm.c2.Rd
+++ b/man/Mm.c2.Rd
@@ -23,7 +23,7 @@ A subset of the object \code{Mm.c2} from Bioconductor workflow RNAseq123.
 }
 \references{
 Law CW, Alhamdoosh M, Su S, Dong X, Tian L, Smyth GK, Ritchie ME.
-\href{https://f1000research.com/articles/5-1408/v3}{RNA-seq analysis is easy as 1-2-3 with limma, Glimma and edgeR \link{version 3; peer review: 3 approved}.}
+\href{https://f1000research.com/articles/5-1408/v3}{RNA-seq analysis is easy as 1-2-3 with limma, Glimma and edgeR [version 3; peer review: 3 approved].}
 F1000Research 2018, 5:1408
 \doi{10.12688/f1000research.9005.3}
 

--- a/man/basal.vs.lp.Rd
+++ b/man/basal.vs.lp.Rd
@@ -33,7 +33,7 @@ A subset of the object \code{basal.vs.lp} from Bioconductor workflow RNAseq123.
 }
 \references{
 Law CW, Alhamdoosh M, Su S, Dong X, Tian L, Smyth GK, Ritchie ME.
-\href{https://f1000research.com/articles/5-1408/v3}{RNA-seq analysis is easy as 1-2-3 with limma, Glimma and edgeR \link{version 3; peer review: 3 approved}.}
+\href{https://f1000research.com/articles/5-1408/v3}{RNA-seq analysis is easy as 1-2-3 with limma, Glimma and edgeR [version 3; peer review: 3 approved].}
 F1000Research 2018, 5:1408
 \doi{10.12688/f1000research.9005.3}
 

--- a/man/basal.vs.ml.Rd
+++ b/man/basal.vs.ml.Rd
@@ -33,7 +33,7 @@ A subset of the object \code{basal.vs.ml} from Bioconductor workflow RNAseq123.
 }
 \references{
 Law CW, Alhamdoosh M, Su S, Dong X, Tian L, Smyth GK, Ritchie ME.
-\href{https://f1000research.com/articles/5-1408/v3}{RNA-seq analysis is easy as 1-2-3 with limma, Glimma and edgeR \link{version 3; peer review: 3 approved}.}
+\href{https://f1000research.com/articles/5-1408/v3}{RNA-seq analysis is easy as 1-2-3 with limma, Glimma and edgeR [version 3; peer review: 3 approved].}
 F1000Research 2018, 5:1408
 \doi{10.12688/f1000research.9005.3}
 

--- a/man/cam.BasalvsLP.Rd
+++ b/man/cam.BasalvsLP.Rd
@@ -29,7 +29,7 @@ A subset of the object \code{cam.BasalvsLP} from Bioconductor workflow RNAseq123
 }
 \references{
 Law CW, Alhamdoosh M, Su S, Dong X, Tian L, Smyth GK, Ritchie ME.
-\href{https://f1000research.com/articles/5-1408/v3}{RNA-seq analysis is easy as 1-2-3 with limma, Glimma and edgeR \link{version 3; peer review: 3 approved}.}
+\href{https://f1000research.com/articles/5-1408/v3}{RNA-seq analysis is easy as 1-2-3 with limma, Glimma and edgeR [version 3; peer review: 3 approved].}
 F1000Research 2018, 5:1408
 \doi{10.12688/f1000research.9005.3}
 

--- a/man/cam.BasalvsML.Rd
+++ b/man/cam.BasalvsML.Rd
@@ -29,7 +29,7 @@ A subset of the object \code{cam.BasalvsML} from Bioconductor workflow RNAseq123
 }
 \references{
 Law CW, Alhamdoosh M, Su S, Dong X, Tian L, Smyth GK, Ritchie ME.
-\href{https://f1000research.com/articles/5-1408/v3}{RNA-seq analysis is easy as 1-2-3 with limma, Glimma and edgeR \link{version 3; peer review: 3 approved}.}
+\href{https://f1000research.com/articles/5-1408/v3}{RNA-seq analysis is easy as 1-2-3 with limma, Glimma and edgeR [version 3; peer review: 3 approved].}
 F1000Research 2018, 5:1408
 \doi{10.12688/f1000research.9005.3}
 

--- a/man/group.Rd
+++ b/man/group.Rd
@@ -28,7 +28,7 @@ A subset of the object \code{group} from Bioconductor workflow RNAseq123.
 }
 \references{
 Law CW, Alhamdoosh M, Su S, Dong X, Tian L, Smyth GK, Ritchie ME.
-\href{https://f1000research.com/articles/5-1408/v3}{RNA-seq analysis is easy as 1-2-3 with limma, Glimma and edgeR \link{version 3; peer review: 3 approved}.}
+\href{https://f1000research.com/articles/5-1408/v3}{RNA-seq analysis is easy as 1-2-3 with limma, Glimma and edgeR [version 3; peer review: 3 approved].}
 F1000Research 2018, 5:1408
 \doi{10.12688/f1000research.9005.3}
 

--- a/man/lane.Rd
+++ b/man/lane.Rd
@@ -28,7 +28,7 @@ A subset of the object \code{lane} from Bioconductor workflow RNAseq123.
 }
 \references{
 Law CW, Alhamdoosh M, Su S, Dong X, Tian L, Smyth GK, Ritchie ME.
-\href{https://f1000research.com/articles/5-1408/v3}{RNA-seq analysis is easy as 1-2-3 with limma, Glimma and edgeR \link{version 3; peer review: 3 approved}.}
+\href{https://f1000research.com/articles/5-1408/v3}{RNA-seq analysis is easy as 1-2-3 with limma, Glimma and edgeR [version 3; peer review: 3 approved].}
 F1000Research 2018, 5:1408
 \doi{10.12688/f1000research.9005.3}
 

--- a/man/lcpm.Rd
+++ b/man/lcpm.Rd
@@ -23,7 +23,7 @@ A subset of the object \code{lcpm} from Bioconductor workflow RNAseq123.
 }
 \references{
 Law CW, Alhamdoosh M, Su S, Dong X, Tian L, Smyth GK, Ritchie ME.
-\href{https://f1000research.com/articles/5-1408/v3}{RNA-seq analysis is easy as 1-2-3 with limma, Glimma and edgeR \link{version 3; peer review: 3 approved}.}
+\href{https://f1000research.com/articles/5-1408/v3}{RNA-seq analysis is easy as 1-2-3 with limma, Glimma and edgeR [version 3; peer review: 3 approved].}
 F1000Research 2018, 5:1408
 \doi{10.12688/f1000research.9005.3}
 

--- a/man/samplenames.Rd
+++ b/man/samplenames.Rd
@@ -23,7 +23,7 @@ A subset of the object \code{samplenames} from Bioconductor workflow RNAseq123.
 }
 \references{
 Law CW, Alhamdoosh M, Su S, Dong X, Tian L, Smyth GK, Ritchie ME.
-\href{https://f1000research.com/articles/5-1408/v3}{RNA-seq analysis is easy as 1-2-3 with limma, Glimma and edgeR \link{version 3; peer review: 3 approved}.}
+\href{https://f1000research.com/articles/5-1408/v3}{RNA-seq analysis is easy as 1-2-3 with limma, Glimma and edgeR [version 3; peer review: 3 approved].}
 F1000Research 2018, 5:1408
 \doi{10.12688/f1000research.9005.3}
 

--- a/man/shared-data.Rd
+++ b/man/shared-data.Rd
@@ -11,7 +11,7 @@ Shared sections for data objects
 }
 \references{
 Law CW, Alhamdoosh M, Su S, Dong X, Tian L, Smyth GK, Ritchie ME.
-\href{https://f1000research.com/articles/5-1408/v3}{RNA-seq analysis is easy as 1-2-3 with limma, Glimma and edgeR \link{version 3; peer review: 3 approved}.}
+\href{https://f1000research.com/articles/5-1408/v3}{RNA-seq analysis is easy as 1-2-3 with limma, Glimma and edgeR [version 3; peer review: 3 approved].}
 F1000Research 2018, 5:1408
 \doi{10.12688/f1000research.9005.3}
 


### PR DESCRIPTION
When markdown support for {roxygen2} was added in https://github.com/abbvie-external/OmicNavigator/commit/46bb2bdf8af5042bdb66848c5b0ffb768752290b, the square brackets in the journal article title _RNA-seq analysis is easy as 1-2-3 with limma, Glimma and edgeR [version 3; peer review: 3 approved]_ were converted to a `\link{}`, which generated the following WARNING from `R CMD check`:

```
W  checking Rd cross-references ...
   Missing link or links in Rd file 'Mm.c2.Rd':
     'version 3; peer review: 3 approved'

   Missing link or links in Rd file 'basal.vs.lp.Rd':
     'version 3; peer review: 3 approved'

   Missing link or links in Rd file 'basal.vs.ml.Rd':
     'version 3; peer review: 3 approved'

   Missing link or links in Rd file 'cam.BasalvsLP.Rd':
     'version 3; peer review: 3 approved'

   Missing link or links in Rd file 'cam.BasalvsML.Rd':
     'version 3; peer review: 3 approved'

   Missing link or links in Rd file 'group.Rd':
     'version 3; peer review: 3 approved'

   Missing link or links in Rd file 'lane.Rd':
     'version 3; peer review: 3 approved'

   Missing link or links in Rd file 'lcpm.Rd':
     'version 3; peer review: 3 approved'

   Missing link or links in Rd file 'samplenames.Rd':
     'version 3; peer review: 3 approved'

   Missing link or links in Rd file 'shared-data.Rd':
     'version 3; peer review: 3 approved'

   See section 'Cross-references' in the 'Writing R Extensions' manual.
```

I fixed it by escaping the square brackets with a backslash.