### PR TITLE
Test that special character in package description is exported

### DIFF
--- a/inst/tinytest/testExport.R
+++ b/inst/tinytest/testExport.R
@@ -22,15 +22,14 @@ dir.create(tmplibQuote)
 
 # Export with special encoding description ------------------------------------
 
-testStudyObj2 <- OmicNavigator:::testStudy(name = testStudyName, description = "Test encoding: β‐catenin and neural cell adhesion molecule (NCAM)")
-testStudyObj2 <- addPlots(testStudyObj2, OmicNavigator:::testPlots())
-minimalStudyObj2 <- OmicNavigator:::testStudyMinimal()
-minimalStudyName2 <- minimalStudyObj2[["name"]]
+specialDesc <- "Test encoding: β‐catenin and neural cell adhesion molecule (NCAM)"
+specialTestStudyObj <- OmicNavigator:::testStudy(name = "ABCspecial",
+                                                 description = specialDesc)
 
-observed <- exportStudy(testStudyObj2, type = "package", path = tmplib)
-expected <- file.path(tmplib, OmicNavigator:::studyToPkg(testStudyName))
-expect_identical_xl(observed, expected, info = "Export as package directory")
-expect_true_xl(dir.exists(expected))
+specialPath <- exportStudy(specialTestStudyObj, type = "package", path = tmplib)
+observed <- read.dcf(file.path(specialPath, "DESCRIPTION"), fields = "Description")
+expect_identical_xl(as.character(observed), specialDesc,
+                    info = "Export special character in description field")
 
 # Export as package directory --------------------------------------------------
 

--- a/inst/tinytest/testExport.R
+++ b/inst/tinytest/testExport.R
@@ -22,7 +22,7 @@ dir.create(tmplibQuote)
 
 # Export with special encoding description ------------------------------------
 
-specialDesc <- "Test encoding: β‐catenin and neural cell adhesion molecule (NCAM)"
+specialDesc <- "β‐catenin and neural cell adhesion molecule (NCAM)"
 specialTestStudyObj <- OmicNavigator:::testStudy(name = "ABCspecial",
                                                  description = specialDesc)
 


### PR DESCRIPTION
Follow up to #52

xref: https://github.com/abbvie-external/OmicNavigator/pull/52#discussion_r2087448406
cc: @ElyseGeoffroy 

I updated the test to explicitly confirm that the special Beta character was exported to the plain text `DESCRIPTION` file. I decided against installing it too since I didn't want to interfere with the `listStudies()` calls in later tests.