### PR TITLE
Configure user.email for pin-app workflow (and add workflow_dispatch)

### DIFF
--- a/.github/workflows/pin-app.yml
+++ b/.github/workflows/pin-app.yml
@@ -9,6 +9,14 @@ name: Pin the app to the latest release version
 on:
   repository_dispatch:
     types: [app-release]
+  workflow_dispatch:
+    inputs:
+      appRef:
+        description: >-
+          The Git tag of OmicNavigatorWebApp to bundle in the R package. Must be of the form
+          "refs/tags/vX.X.X" to function correctly.
+        required: true
+        default: refs/tags/vX.X.X
 
 jobs:
   dev:
@@ -16,20 +24,44 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          token: ${{ secrets.REPO_ACCESS_TOKEN }}
+          # Using the default github.token as a fallback enables testing the
+          # workflow on a fork
+          token: ${{ secrets.REPO_ACCESS_TOKEN || github.token }}
 
       - name: Extract app version from event payload
         env:
-          appRef: ${{ github.event.client_payload.ref }}
+          appRef: ${{ github.event.client_payload.ref || github.event.inputs.appRef }}
         run: echo "appVersion=${appRef#refs/tags/v}" >> $GITHUB_ENV
 
       - name: Configure Git
         run: |
           git config --local user.name 'GitHub Actions'
-          # I purposefully want to simply use auto-generated email for now
+          git config user.email runneradmin@users.noreply.github.com
 
       - name: Bump pinned app version in R package
         run: Rscript scripts/bump-app-version.R ${{ env.appVersion }}
 
       - name: Commit, tag, and push
-        run: bash scripts/commit-tag-push.sh
+        # Only push commit to the repository if the following conditions are
+        # satisfied:
+        #
+        # 1) The workflow is running in the original repository
+        # AND
+        # 2) One of the following two conditions are satisfied:
+        #   A) The workflow was triggered by a repository_dispatch event
+        #   OR
+        #   B) The workflow was triggered by a workflow_dispatch event
+        #      running on the main branch
+        if: >-
+          github.repository == 'abbvie-external/OmicNavigator'
+          &&
+          (
+            github.event_name == 'repository_dispatch'
+            ||
+            (
+              github.event_name == 'workflow_dispatch'
+              &&
+              github.ref == 'refs/heads/main'
+            )
+          )
+        run: bash -x scripts/commit-tag-push.sh

--- a/scripts/bump-app-version.R
+++ b/scripts/bump-app-version.R
@@ -65,4 +65,4 @@ writeLines(git, gitScript)
 
 message("\nRun the following Git commands:\n")
 message(paste(git, collapse = "\n"))
-message(sprintf("\nOr run: bash %s", gitScript))
+message(sprintf("\nOr run: bash -x %s", gitScript))


### PR DESCRIPTION
The pin-app workflow recently failed spuriously because a value for `user.email` was not auto-generated. It was fixed by a simple restart, but it'd be best to avoid these spurious failures in the future.

In this PR, I explicitly define a `user.email` to sign the bot commit, as well as the following:

1. Increase transparency by running the bash script with `-x` to print the commands. This will make it easier to read the build logs for future troubleshooting
2. Added a manual trigger (`workflow_dispatch`). This will allow us to test the workflow, even on forks, without having any consequences. Furthermore, if for some reason you do want to recreate the `repository_dispatch` event manually, you can manually trigger the workflow from the main branch, which will push to main with the version of OmicNavigatorWebApp that you specify

I tested the manual trigger on my fork. It runs the workflow using the Git tag I provided, but skips the push step since it is running on a fork.

xref: #57
cc: @bengalengel, @paulnordlund
