### PR TITLE
Fix tests of buildPkg()

### DIFF
--- a/inst/tinytest/testExport.R
+++ b/inst/tinytest/testExport.R
@@ -108,26 +108,18 @@ if (at_home()) {
 
   # Return warning message if package fails to build
   pkgDir <- tempfile(pattern = OmicNavigator:::getPrefix())
-  e <- new.env(parent = emptyenv())
-  # This function gets added to the package with an incomplete Rd file, which
-  # causes an error during the build
-  e$x <- function() 1 + 1
-  suppressMessages(
-    utils::package.skeleton(
-      name = basename(pkgDir),
-      path = tempdir(),
-      environment = e
-    )
-  )
+  dir.create(pkgDir, showWarnings = FALSE, recursive = TRUE)
+  # Use invalid package name to trigger build failure
+  writeLines("Package: 1pkg", con = file.path(pkgDir, "DESCRIPTION"))
 
   expect_warning_xl(
     OmicNavigator:::buildPkg(pkgDir),
-    "ERROR: package installation failed",
+    "Malformed package name",
     info = "Return warning message for failed package build"
   )
 
-  # Remove the problematic man file
-  file.remove(file.path(pkgDir, "man", "x.Rd"))
+  # Fix the problematic package name
+  writeLines("Package: onepkg", con = file.path(pkgDir, "DESCRIPTION"))
 
   expect_silent_xl(
     tarball <- OmicNavigator:::buildPkg(pkgDir)


### PR DESCRIPTION
Our test to confirm that `buildPkg()` properly transmits the error from `R CMD build` is failing:

```R
library(OmicNavigator)
## OmicNavigator R package version: 1.14.19
## OmicNavigator app version: 1.9.8

tinytest::run_test_file("inst/tinytest/testExport.R")
## testExport.R..................   41 tests 1 fails 14.0s
## ----- FAILED[xcpt]: testExport.R<69--138>
##  call| expect_warning_xl(OmicNavigator:::buildPkg(pkgDir), "ERROR: package installation failed",
##  call| -->    info = "Return warning message for failed package build")
##  diff| No warning was emitted
##  info| Return warning message for failed package build
##
## Showing 1 out of 41 results: 1 fails, 40 passes (14.0s)
```

The good news is that the problem is with the test, not our function.

When I first wrote that test, `R CMD build` would fail to build the default package created by `package.skeleton()`. I couldn't find anything in the NEWS or source that would indicate a change in `package.skeleton()` output or for more flexibility in building `.Rd` files:

https://github.com/wch/r-source/commits/trunk/src/library/utils/R/package.skeleton.R
https://cloud.r-project.org/doc/manuals/r-release/NEWS.html
https://cloud.r-project.org/doc/manuals/NEWS.3

Fortunately, I was able to recreate the tests using a simple malformed package name.

```R
# with this PR
devtools::load_all(".")
tinytest::run_test_file("inst/tinytest/testExport.R")
## testExport.R..................   41 tests OK 11.6s
## All ok, 41 results (11.6s)
```