### PR TITLE
Update URL for Ensembl favicon returned by getFavicons()

### DIFF
--- a/inst/tinytest/testApp.R
+++ b/inst/tinytest/testApp.R
@@ -500,7 +500,7 @@ if (at_home()) {
     list(
       default = list(
         customID = c(
-          "https://ensembl.org/i/ensembl-favicon.png",
+          "https://static.ensembl.org/i/ensembl-favicon.png",
           "https://www.targetvalidation.org/favicon.png"
         ),
         featureVar01 = c(


### PR DESCRIPTION
The URL to the Ensembl favicon returned by `getFavicons()` has changed. This PR fixes the test.

```R
tinytest::run_test_file("inst/tinytest/testApp.R")

----- FAILED[data]: testApp.R<494--539>
 call| expect_identical_xl(getFavicons(getResultsLinkouts(testStudyName)), 
 call| -->    list(default = list(customID = c("https://ensembl.org/i/ensembl-favicon.png", 
 call| -->        "https://www.targetvalidation.org/favicon.png"), featureVar01 = c("https://www.ncbi.nlm.nih.gov/favicon.ico")), 
 call| -->        model_03 = list(featureVar02 = c("https://www.ncbi.nlm.nih.gov/favicon.ico"))))
 diff| < target                                                                                           
 diff| > current                                                                                          
 diff| @@ 1,5 / 1,6 @@                                                                                    
 diff| $default                                                                                         
 diff| $default$customID                                                                                
 diff| > [1] "https://static.ensembl.org/i/ensembl-favicon.png"                                           
 diff| < [1] "https://ensembl.org/i/ensembl-favicon.png"    "https://www.targetvalidation.org/favicon.png"
 diff| > [2] "https://www.targetvalidation.org/favicon.png"                                               
 diff| 
 diff| $default$featureVar01                                                                            
 
Showing 1 out of 790 results: 1 fails, 789 passes (1m 11.9s)
```

xref: https://github.com/jdblischak/faviconPlease/commit/ea84b7fbd4a9ed898436c1994cc711152b1fd057, https://github.com/jdblischak/faviconPlease/commit/a3c1d7e471e127261ccfbaee51ef27359b36a85b