### PR TITLE
Clarify use of at_home() for {tinytest}

### DIFF
--- a/.github/workflows/comprehensive.yml
+++ b/.github/workflows/comprehensive.yml
@@ -70,7 +70,6 @@ jobs:
         env:
           R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
           _R_CHECK_CRAN_INCOMING_REMOTE_: false
-          TT_AT_HOME: TRUE
         run: R CMD check --no-manual --as-cran OmicNavigator_*.tar.gz
       - name: Test results
         if: always()

--- a/.github/workflows/quick.yml
+++ b/.github/workflows/quick.yml
@@ -38,8 +38,6 @@ jobs:
         sessionInfo()
       shell: Rscript {0}
     - name: Test
-      env:
-        TT_AT_HOME: TRUE
       run: suppressMessages(tinytest::test_package("OmicNavigator", ncpu = 2))
       shell: Rscript {0}
     - name: Run vignettes

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -180,6 +180,11 @@ output too much, you can wrap the tinytest function call with
 `suppressMessages()`. This will suppress the messages from the OmicNavigator
 functions but still display the test results.
 
+* Note that the tests wrapped in `at_home()` are only executed when running
+`tinytest::test_all()` or `tinytest::run_test_file()`. They are skipped when
+running `test_package()` (which is what is called by `R CMD check`), and thus
+these tests are not run in GitHub Actions or on CRAN servers.
+
 Lastly, if you are making a large contribution, it can be helpful to evaluate
 the comprehensiveness of your tests by calculating the test coverage. The covr
 package runs the package tests and creates a report that details which lines

--- a/inst/tinytest/testExport.R
+++ b/inst/tinytest/testExport.R
@@ -62,9 +62,10 @@ expect_true_xl(dir.exists(expected))
 # Export as package tarball ----------------------------------------------------
 
 # These tests fail on all CRAN macOS machines and most CRAN Linux machines. I
-# have no idea why. The call to `R CMD build` looks fine, so I don't know what
-# more I could do on my end to fix the failed tarball creation. I skip them on
-# CRAN but still continue to test locally and on GitHub Actions.
+# have no idea why. They also fail in GitHub Actions. The call to `R CMD build`
+# looks fine, so I don't know what more I could do on my end to fix the failed
+# tarball creation. They are only tested locally when running
+# tinytest::test_all() or tinytest::run_test_file()
 
 if (at_home()) {
   tarball <- exportStudy(testStudyObj, type = "tarball", path = tmplib)


### PR DESCRIPTION
I realized that when I initially wrote the {tinytest} tests, I confused myself about how `at_home()` works. I expected `at_home()` and the env var `TT_AT_HOME` to work identically to `skip_on_cran` and `NOT_CRAN` do for {testthat}. They do not (https://github.com/markvanderloo/tinytest/issues/10)

Essentially `TT_AT_HOME` is an env var used internally by {tinytest}. It is not intended to be used directly by the end user. Whether or not tests wrapped in `if (at_home()) {}` are executed is determined not by the value of `TT_AT_HOME` in the user's environment but instead by the value of the argument `at_home` passed to the tinytest function.

By default `test_all()` and `run_test_file()` set `at_home = TRUE`, and `test_package()` sets `at_home = FALSE`. Thus the `at_home()` tests have never run in our GitHub Actions workflows, despite me having set `TT_AT_HOME: TRUE`.

In retrospect this is a good thing. I have learned from testing URLs in GitHub Actions for {faviconPlease} that sometimes the results when running in GitHub Actions don't match the results on my local machine, which is super frustrating (https://github.com/jdblischak/faviconPlease/commit/a3c1d7e471e127261ccfbaee51ef27359b36a85b). Also, when I did set `tinytest::test_package("OmicNavigator", at_home = TRUE)` in the quick test workflow, it failed the same package tarball tests that fail on CRAN machines. I still don't know why. If I set `tinytest::test_package("OmicNavigator", at_home = TRUE)` on my local machine, the tests run fine (even when run via `R CMD check`).

In summary, we will continue to only run flaky tests (favicons, exporting package tarballs) locally. They will not run in GitHub Actions or on CRAN. This PR simply clarifies the existing situation.