### PR TITLE
Use r2u-setup action

### DIFF
--- a/.github/workflows/quick.yml
+++ b/.github/workflows/quick.yml
@@ -24,7 +24,9 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Setup r2u
-      run: sudo bash scripts/setup-r2u.sh
+      uses: eddelbuettel/github-actions/r2u-setup@master
+      with:
+        bspm-version-check: "FALSE"
     - name: Install R packages
       run: sudo bash scripts/install-dependencies-r2u.sh
     - name: Build OmicNavigator

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,9 @@ jobs:
       with:
         ref: ${{ github.event.inputs.pkgRef || github.ref }}
     - name: Setup r2u
-      run: sudo bash scripts/setup-r2u.sh
+      uses: eddelbuettel/github-actions/r2u-setup@master
+      with:
+        bspm-version-check: "FALSE"
     - name: Install R packages
       run: sudo bash scripts/install-dependencies-r2u.sh
     - name: Create diagrams for vignettes


### PR DESCRIPTION
Migrate from our custom script to official [r2u-setup](https://github.com/eddelbuettel/github-actions/tree/aa4a2285105edd66e3d5fc7db73dfe8a98254879/r2u-setup) action

Here is the manually triggered [run](https://github.com/jdblischak/OmicNavigator/actions/runs/15216040318) on my fork that uses the r2u-setup action

Notes:

* The action was originally designed for `ubuntu-22.04`, which is what we are currently running. However, it in theory should support later Ubuntu versions, so it will hopefully be smooth when we upgrade to a newer runner (at least easier than manually updating our own script)

* I didn't delete `scripts/setup-r2u.sh` because it is still used by the Docker container

https://github.com/abbvie-external/OmicNavigator/blob/2e301aaff714968a764234b35330cc4ccce11c98/Dockerfile#L7

* Our pin-app workflow currently relies on the default version of R installed in the GitHub runner. I know R has been removed in the default image, which I believe started in ubuntu-24.04. So when we migrate, we'll need to add a step to install R via `r2u-setup`

* The purpose of `bspm-version-check: "FALSE"` is to prevent installing any packages from source. This is error prone, and our package is fine working with recent versions of our dependencies. In other words, there is no motivation to risk a source installation of the latest version of a dependency when the latest available binary is sufficient.