### PR TITLE
Reduce troubleshooting releases in NEWS

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,65 +2,9 @@
 
 * The release tarball includes version 1.9.8 of the web app
 
-# 1.14.18
+# 1.14.4 - 1.14.18
 
-* The release tarball includes version 1.9.7 of the web app
-
-# 1.14.17
-
-* The release tarball includes version 1.9.7 of the web app
-
-# 1.14.16
-
-* The release tarball includes version 1.9.7 of the web app
-
-# 1.14.15
-
-* The release tarball includes version .1.9.7 of the web app
-
-# 1.14.14
-
-* The release tarball includes version 1.9.7 of the web app
-
-# 1.14.13
-
-* The release tarball includes version 1.9.7 of the web app
-
-# 1.14.12
-
-* The release tarball includes version 1.9.7 of the web app
-
-# 1.14.11
-
-* The release tarball includes version 1.9.7 of the web app
-
-# 1.14.10
-
-* The release tarball includes version 1.9.7 of the web app
-
-# 1.14.9
-
-* The release tarball includes version 1.9.7 of the web app
-
-# 1.14.8
-
-* The release tarball includes version 1.9.7 of the web app
-
-# 1.14.7
-
-* The release tarball includes version 1.9.7 of the web app
-
-# 1.14.6
-
-* The release tarball includes version 1.9.7 of the web app
-
-# 1.14.5
-
-* The release tarball includes version 1.9.7 of the web app
-
-# 1.14.4
-
-* The release tarball includes version 1.9.7 of the web app
+* For troubleshooting only
 
 # 1.14.3
 


### PR DESCRIPTION
The release workflow [failed](https://github.com/abbvie-external/OmicNavigator/actions/runs/13547195673) back in Feb 2025 when attempting to create release 1.14.3 with 1.9.7 of the web app. This PR documents and cleans up the troubleshooting-only releases.

* In the GitHub UI, I manually created release [1.14.3](https://github.com/abbvie-external/OmicNavigator/releases/tag/v1.14.3) from the existing tag. Since this wasn't created by the workflow, it doesn't have its release assets attached.
* In the GitHub UI, I manually set [1.14.19](https://github.com/abbvie-external/OmicNavigator/releases/tag/v1.14.19) to be labeled the "latest" again
* In the GitHub UI, I manually deleted tags 1.14.4 through 1.14.18
* Locally I deleted the tags 1.14.4 through 1.14.18 to prevent accidentally pushing them again
* I reduced the `NEWS.md` entries

Going forward, there are now manual triggers (`workflow_dispatch`) for both the pin-app (#58) and release (#62) workflows. We can use these for troubleshooting without creating side effects like tags or releases.

cc: @bengalengel, @ternst23 

For more documentation, here are the commits that each tag I deleted used to be connected to:

```sh
git tag -d v1.14.4
## Deleted tag 'v1.14.4' (was 014de03)
git tag -d v1.14.5
## Deleted tag 'v1.14.5' (was 27b061e)
git tag -d v1.14.6
## Deleted tag 'v1.14.6' (was 4da1120)
git tag -d v1.14.7
## Deleted tag 'v1.14.7' (was eb6cbfc)
git tag -d v1.14.8
## Deleted tag 'v1.14.8' (was 4e6b440)
git tag -d v1.14.9
## Deleted tag 'v1.14.9' (was a72a11c)
git tag -d v1.14.10
## Deleted tag 'v1.14.10' (was f5c0a08)
git tag -d v1.14.11
## Deleted tag 'v1.14.11' (was 1371ad6)
git tag -d v1.14.12
## Deleted tag 'v1.14.12' (was 7e06a50)
git tag -d v1.14.13
## Deleted tag 'v1.14.13' (was 2cffc76)
git tag -d v1.14.14
## Deleted tag 'v1.14.14' (was 15da45e)
git tag -d v1.14.15
## Deleted tag 'v1.14.15' (was 578cb69)
git tag -d v1.14.16
## Deleted tag 'v1.14.16' (was 78712d7)
git tag -d v1.14.17
## Deleted tag 'v1.14.17' (was e432b71)
git tag -d v1.14.18
## Deleted tag 'v1.14.18' (was b214f9b)
```