### PR TITLE
Use full URL to deployment docs to avoid NOTE from R CMD check

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,7 +221,9 @@ xml2 | libxml-2.0 | Solaris | libxml2_dev
 
 ## Deployment with Docker
 
-If you would like to serve OmicNavigator please refer to the [Deployment](./Deployment.md) document. The instructions within this document outline the fastest way to prepare the OmicNavigator software for deployment using a [Docker](https://www.docker.com/) container. It also includes instructions for installing your custom OmicNavigator studies within the container. 
+If you would like to serve OmicNavigator please refer to the [Deployment][deployment] document. The instructions within this document outline the fastest way to prepare the OmicNavigator software for deployment using a [Docker](https://www.docker.com/) container. It also includes instructions for installing your custom OmicNavigator studies within the container.
+
+[deployment]: https://github.com/abbvie-external/OmicNavigator/blob/main/Deployment.md
 
 ## Acknowledgements
 


### PR DESCRIPTION
We currently use a relative path `./Deployment.md` in our README. Personally I prefer this approach. That way no matter what branch you are viewing the README from, if you click on the link, it will keep you in the same branch.

However, when I tested on win-builder (via `devtools::check_win_devel()`), I got the following NOTE:

```R
* checking CRAN incoming feasibility ... [15s] NOTE
Maintainer: 'John Blischak <jdblischak@gmail.com>'

Found the following (possibly) invalid file URI:
  URI: ./Deployment.md
    From: README.md
```

This is clearly a false-positive, and we could attempt to argue the case. But as that file isn't included in the package tarball (it's not allowed to), technically the link doesn't work.

And the key to a quick CRAN submission is to have absolutely zero errors, warnings, or even notes. By removing this NOTE, we increase the chance that the package is auto-accepted to CRAN.