### PR TITLE
Remove calls to deprecated ggplot2::qplot()

### DIFF
--- a/R/tests.R
+++ b/R/tests.R
@@ -258,8 +258,10 @@ testPlots <- function() {
     featureMedian <- stats::median(plotPoints)
     plotTitle <- sprintf("%s, median: %0.2f", x[["features"]][["customID"]],
                          featureMedian)
-    ggplot2::qplot(seq_along(plotPoints), plotPoints, main = plotTitle,
-                   xlab = "Samples", ylab = "Expression level")
+    d <- data.frame(i = seq_along(plotPoints), plotPoints)
+    ggplot2::ggplot(d, ggplot2::aes(x = .data$i, y = .data$plotPoints)) +
+      ggplot2::geom_point() +
+      ggplot2::labs(x = "Samples", y = "Expression level", title = plotTitle)
   }
   assign("plotGg", plotGg, envir = parent.frame())
   plotMultiFeature <- function(x) {
@@ -329,8 +331,10 @@ testPlots <- function() {
     featureMedian <- stats::median(plotPoints)
     plotTitle <- sprintf("%s, median: %0.2f", x[["features"]][["customID"]],
                          featureMedian)
-    p <- ggplot2::qplot(seq_along(plotPoints), plotPoints, main = plotTitle,
-                   xlab = "Samples", ylab = "Expression level")
+    d <- data.frame(i = seq_along(plotPoints), plotPoints)
+    p <- ggplot2::ggplot(d, ggplot2::aes(x = .data$i, y = .data$plotPoints)) +
+      ggplot2::geom_point() +
+      ggplot2::labs(x = "Samples", y = "Expression level", title = plotTitle)
     plotly::ggplotly(p)
   }
   assign("plotPlotly", plotPlotly, envir = parent.frame())

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -83,3 +83,10 @@ appPackages <- c(
 # Make the internal package functions "data.table aware"
 # https://rdatatable.gitlab.io/data.table/articles/datatable-importing.html#data-table-in-imports-but-nothing-imported-1
 .datatable.aware <- TRUE
+
+# Avoid NOTE from `R CMD check`: no visible binding for global variable '.data'
+.data <- NULL
+# Used by {ggplot2} for example plots in tests.R. The official guidance is to
+# import rlang::.data into the NAMESPACE, but it's not worth adding {rlang} to
+# Imports for this minor test usage.
+# https://ggplot2.tidyverse.org/articles/ggplot2-in-packages.html#using-aes-and-vars-in-a-package-function


### PR DESCRIPTION
Closes #69 
cc: @teunbrand

The soon-to-be-released {ggplot2} 4.0 throws a warning if the deprecated `qplot()` is used, which breaks some of our unit tests that expect the plotting functions to be silent. And in the future the warnings will be elevated to errors, so it is best to fix this now. The use of `qplot()` was purely for the sake of convenience.

The main complication of using the standard `ggplot()` call is that it requires dealing with non-standard evaluation. I partially followed the [official guidance](https://ggplot2.tidyverse.org/articles/ggplot2-in-packages.html#using-aes-and-vars-in-a-package-function) on using `aes()` inside of a package function. I reference the variables using the special prefix `.data$`. However, I didn't add `.data` to the NAMESPACE because I didn't want to add {rlang} to Imports for such a minor usage in our package. Instead I simply defined a global variable `.data` and assigned it `NULL`.

I did extra manual tests to confirm the test plotting functions `plotGg()` and `plotPlotly()` continue to work as expected.

```R
library("OmicNavigator")

# Create test study
testStudyName <- "ABC"
testStudyObj <- OmicNavigator:::testStudy(name = testStudyName)
plots <- OmicNavigator:::testPlots()
testStudyObj <- addPlots(testStudyObj, plots)

# Confirm plotting functions work
plotStudy(testStudyObj, modelID = "model_03", featureID = "feature_0001", plotID = "plotGg")
json <- plotStudy(testStudyObj, modelID = "model_03", featureID = "feature_0001", plotID = "plotPlotly")
class(json)
## [1] "json"

# Install test study in temporary directory
tmplib <- tempfile()
dir.create(tmplib)
libOrig <- .libPaths()
.libPaths(c(tmplib, libOrig))
suppressMessages(installStudy(testStudyObj))
testPkgName <- paste0(OmicNavigator:::getPrefix(), testStudyName)

# Confirm plotting functions work
plotStudy(testStudyName, modelID = "model_03", featureID = "feature_0001", plotID = "plotGg")
json <- plotStudy(testStudyName, modelID = "model_03", featureID = "feature_0001", plotID = "plotPlotly")
class(json)

# Run the app to confirm both plots work in interactive session
installApp()
## Installation plan:
##   Version: 1.9.9
## URL: https://github.com/abbvie-external/OmicNavigatorWebApp/releases/download/v1.9.9/build.zip
## Installing to C:/Users/john/AppData/Local/R/win-library/4.4/OmicNavigator/www
## Success!
startApp()
```

Screenshot of `plotGg()`:

<img width="1824" height="476" alt="image" src="https://github.com/user-attachments/assets/3a69f5b9-b376-4249-9037-a0e77d981392" />

Screenshot of `plotPlotly()`:

<img width="1819" height="575" alt="image" src="https://github.com/user-attachments/assets/ecf77874-b6f7-41ec-ba64-5b35d960ba46" />

