### PR TITLE
Enable sharing of plotting functions across subset of models

### DIFF
--- a/R/add.R
+++ b/R/add.R
@@ -387,6 +387,14 @@ addMetaFeatures <- function(study, metaFeatures, reset = FALSE) {
 #' Fortunately this latter code will also run fine as you interactively develop
 #' the function.
 #'
+#' Note that the plotting functions are written to the R package when the study
+#' is exported via \code{\link{exportStudy}} or installed via
+#' \code{\link{installStudy}}, not when \code{addPlots} is invoked. In other
+#' words, if you add a custom plotting function to your study object via
+#' \code{addPlots}, but then subsequently update the function in the global
+#' environment prior to installing the study, this latest version will be saved
+#' in the R package and executed when run in the app.
+#'
 #' @param plots A nested list containing custom plotting functions and plot
 #'   metadata. The input object is a 3-level nested list. The first, or
 #'   top-level list element name(s) must match the study `modelID`(s). The second,
@@ -406,8 +414,8 @@ addMetaFeatures <- function(study, metaFeatures, reset = FALSE) {
 #'   within the model specified by the top-level list element name), and 4) if
 #'   the plot is interactive (add “`plotly`” to specify interactive plots built
 #'   using the plotly package; otherwise the plot is assumed to be static).
-#'   e.g., `plotType = c("multiFeature", "multiTest",”plotly”)`. If you do not
-#'   specify the `plotType` the plot will be designated as `plotType =
+#'   e.g., `plotType = c("multiFeature", "multiTest", "plotly")`. If you do not
+#'   specify the `plotType`, the plot will be designated as `plotType =
 #'   c("singleFeature", "singleTest")`. The `models` field is an optional
 #'   character vector that specifies the models that should be used by the app
 #'   when invoking your custom plotting function. This field is set to ‘all’ by
@@ -415,7 +423,11 @@ addMetaFeatures <- function(study, metaFeatures, reset = FALSE) {
 #'   is not included the app will assume all models in the study should be used
 #'   with your plotting function. If the plotting function requires additional
 #'   packages beyond those attached by default to a fresh R session, these must
-#'   be defined in the element `packages`.
+#'   be defined in the element `packages`. To share a plotting functions across
+#'   multiple models, use the modelID "default". Alternatively, to share a plot
+#'   across a specific subset of models, you can explicitly add the same
+#'   plotting function to each model (option available as of OmicNavigator
+#'   1.16.0).
 #'
 #' @inherit shared-add
 #'

--- a/inst/tinytest/testPlot.R
+++ b/inst/tinytest/testPlot.R
@@ -993,6 +993,7 @@ expect_error(
 
 # Teardown ---------------------------------------------------------------------
 
+# todo: plotStudy() should unload study package namespace if it wasn't already loaded
 unloadNamespace(testPkgName)
 unlink(tmplib, recursive = TRUE, force = TRUE)
 .libPaths(libOrig)

--- a/man/addPlots.Rd
+++ b/man/addPlots.Rd
@@ -28,15 +28,19 @@ used in the plot; otherwise the plot is assumed to reference only data
 within the model specified by the top-level list element name), and 4) if
 the plot is interactive (add “\code{plotly}” to specify interactive plots built
 using the plotly package; otherwise the plot is assumed to be static).
-e.g., \verb{plotType = c("multiFeature", "multiTest",”plotly”)}. If you do not
-specify the \code{plotType} the plot will be designated as \code{plotType = c("singleFeature", "singleTest")}. The \code{models} field is an optional
+e.g., \code{plotType = c("multiFeature", "multiTest", "plotly")}. If you do not
+specify the \code{plotType}, the plot will be designated as \code{plotType = c("singleFeature", "singleTest")}. The \code{models} field is an optional
 character vector that specifies the models that should be used by the app
 when invoking your custom plotting function. This field is set to ‘all’ by
 default and is only used when \code{plotType} includes “\code{multiModel}”. If this field
 is not included the app will assume all models in the study should be used
 with your plotting function. If the plotting function requires additional
 packages beyond those attached by default to a fresh R session, these must
-be defined in the element \code{packages}.}
+be defined in the element \code{packages}. To share a plotting functions across
+multiple models, use the modelID "default". Alternatively, to share a plot
+across a specific subset of models, you can explicitly add the same
+plotting function to each model (option available as of OmicNavigator
+1.16.0).}
 
 \item{reset}{Reset the data prior to adding the new data (default:
 \code{FALSE}). The default is to add to or modify any previously added data
@@ -72,6 +76,14 @@ columns of the data frame, e.g. \code{aes(x = group)}, you need to prefix it
 with \code{.data$}, so that it becomes \code{aes(x = .data$group)}.
 Fortunately this latter code will also run fine as you interactively develop
 the function.
+
+Note that the plotting functions are written to the R package when the study
+is exported via \code{\link{exportStudy}} or installed via
+\code{\link{installStudy}}, not when \code{addPlots} is invoked. In other
+words, if you add a custom plotting function to your study object via
+\code{addPlots}, but then subsequently update the function in the global
+environment prior to installing the study, this latest version will be saved
+in the R package and executed when run in the app.
 }
 \seealso{
 \code{\link{getPlottingData}}, \code{\link{plotStudy}}

--- a/man/createStudy.Rd
+++ b/man/createStudy.Rd
@@ -125,15 +125,19 @@ used in the plot; otherwise the plot is assumed to reference only data
 within the model specified by the top-level list element name), and 4) if
 the plot is interactive (add “\code{plotly}” to specify interactive plots built
 using the plotly package; otherwise the plot is assumed to be static).
-e.g., \verb{plotType = c("multiFeature", "multiTest",”plotly”)}. If you do not
-specify the \code{plotType} the plot will be designated as \code{plotType = c("singleFeature", "singleTest")}. The \code{models} field is an optional
+e.g., \code{plotType = c("multiFeature", "multiTest", "plotly")}. If you do not
+specify the \code{plotType}, the plot will be designated as \code{plotType = c("singleFeature", "singleTest")}. The \code{models} field is an optional
 character vector that specifies the models that should be used by the app
 when invoking your custom plotting function. This field is set to ‘all’ by
 default and is only used when \code{plotType} includes “\code{multiModel}”. If this field
 is not included the app will assume all models in the study should be used
 with your plotting function. If the plotting function requires additional
 packages beyond those attached by default to a fresh R session, these must
-be defined in the element \code{packages}.}
+be defined in the element \code{packages}. To share a plotting functions across
+multiple models, use the modelID "default". Alternatively, to share a plot
+across a specific subset of models, you can explicitly add the same
+plotting function to each model (option available as of OmicNavigator
+1.16.0).}
 
 \item{mapping}{Feature IDs from models. The input object is a list of named
 data frames. For each data frame, column names indicate model names while


### PR DESCRIPTION
This PR enables sharing of plotting functions across a subset of models. Previously custom plotting functions could only be shared across models via the special modelID "default", but this was unnecessarily restrictive. This PR removes the `stop()` that prevented this possibility on export, updates the package writing code to only write each plotting function once, and also adds some tests for this new behavior.

cc: @ElyseGeoffroy

While writing the tests, I ran into the same problem I had back in June 2020 (https://github.com/abbvie-external/OmicNavigator/commit/6aab4bbcbfffbdc4799d7e1b38672df329d3021c). Namely that `plotStudy()` doesn't unload the study package from the loaded namespaces. This is unlikely to affect end users, since they are unlikely to be iteratively installing and removing study packages in the same manner as our unit tests, but long term I would like to update `plotStudy()` to clean up the loaded namespaces just like it already does for attached packages and the `par()` settings.