### PR TITLE
Add the argument `requireValid` to `installStudy()`

### DIFF
--- a/R/export.R
+++ b/R/export.R
@@ -4,7 +4,8 @@
 #' @param type Export study as a package tarball ("tarball") or as a package
 #'   directory ("package")
 #' @param path Optional file path to save the object
-#' @param requireValid Require that study is valid before exporting
+#' @param requireValid Require that study is valid before exporting (via
+#'   \code{\link{validateStudy}})
 #'
 #' @return Invisibly returns the name of the tarball file ("tarball") or the
 #'   path to the package directory ("package")
@@ -525,19 +526,33 @@ createPackage <- function(study, directoryname) {
 #' Install a study as an R package
 #'
 #' @param study An OmicNavigator study to install (class \code{onStudy})
+#' @param requireValid Require that study is valid before installing (passed to
+#'   \code{\link{exportStudy}}, which runs \code{\link{validateStudy}})
 #' @param library Directory to install package. Defaults to first directory
 #'   returned by \code{\link{.libPaths}}.
 #'
 #' @return Invisibly returns the original \code{onStudy} object that was passed
 #'   to the argument \code{study}
 #'
+#' @details Note that \code{installStudy} is only intended for directly
+#'   installing an OmicNavigator study object loaded in your current R session.
+#'   If you have already exported your study to a package tarball via
+#'   \code{\link{exportStudy}}, then you can install it with
+#'   \code{\link[utils]{install.packages}}, for example:
+#'
+#'   \preformatted{
+#'   tarball <- exportStudy(myStudy)
+#'   install.packages(tarball, repos = NULL)
+#'   }
+#'
 #' @export
-installStudy <- function(study, library = .libPaths()[1]) {
+installStudy <- function(study, requireValid = TRUE, library = .libPaths()[1]) {
   stopifnot(inherits(study, "onStudy"), dir.exists(library))
   message(sprintf("Installing study \"%s\" in %s", study[["name"]], library))
 
   tmpPath <- if (getRversion() >= "3.5.0") tempdir(check = TRUE) else tempdir()
-  tmpPkgDir <- exportStudy(study, type = "package", path = tmpPath)
+  tmpPkgDir <- exportStudy(study, type = "package", path = tmpPath,
+                           requireValid = requireValid)
   on.exit(unlink(tmpPkgDir, recursive = TRUE, force = TRUE), add = TRUE)
   optionWarn <- getOption("warn", default = 0)
   on.exit(options(warn = optionWarn), add = TRUE)

--- a/inst/tinytest/testExport.R
+++ b/inst/tinytest/testExport.R
@@ -233,6 +233,16 @@ expect_error_xl(
   "Couldn't find"
 )
 
+# Install invalid study object -------------------------------------------------
+
+# Create invalid study due to an invalid column name for featureID
+invalidStudy <- testStudyObj
+colnames(invalidStudy[["results"]][[1]][[1]])[1] <- "wrongFeatureID"
+expect_error_xl(validateStudy(invalidStudy))
+
+expect_error_xl(installStudy(invalidStudy, library = tmplib))
+expect_silent_xl(installStudy(invalidStudy, requireValid = FALSE, library = tmplib))
+
 # Teardown ---------------------------------------------------------------------
 
 unlink(c(tmplib, tmplibSpace, tmplibQuote), recursive = TRUE, force = TRUE)

--- a/man/exportStudy.Rd
+++ b/man/exportStudy.Rd
@@ -19,7 +19,8 @@ directory ("package")}
 
 \item{path}{Optional file path to save the object}
 
-\item{requireValid}{Require that study is valid before exporting}
+\item{requireValid}{Require that study is valid before exporting (via
+\code{\link{validateStudy}})}
 }
 \value{
 Invisibly returns the name of the tarball file ("tarball") or the

--- a/man/installStudy.Rd
+++ b/man/installStudy.Rd
@@ -4,10 +4,13 @@
 \alias{installStudy}
 \title{Install a study as an R package}
 \usage{
-installStudy(study, library = .libPaths()[1])
+installStudy(study, requireValid = TRUE, library = .libPaths()[1])
 }
 \arguments{
 \item{study}{An OmicNavigator study to install (class \code{onStudy})}
+
+\item{requireValid}{Require that study is valid before installing (passed to
+\code{\link{exportStudy}}, which runs \code{\link{validateStudy}})}
 
 \item{library}{Directory to install package. Defaults to first directory
 returned by \code{\link{.libPaths}}.}
@@ -18,4 +21,16 @@ to the argument \code{study}
 }
 \description{
 Install a study as an R package
+}
+\details{
+Note that \code{installStudy} is only intended for directly
+installing an OmicNavigator study object loaded in your current R session.
+If you have already exported your study to a package tarball via
+\code{\link{exportStudy}}, then you can install it with
+\code{\link[utils]{install.packages}}, for example:
+
+\preformatted{
+  tarball <- exportStudy(myStudy)
+  install.packages(tarball, repos = NULL)
+  }
 }


### PR DESCRIPTION
To allow a user to install an invalid study if they so choose via `requireValid = FALSE`. It might be the case that only part of the study is invalid, and they want to explore the valid subset. Also possible they purposefully want to install a work-in-progress study.