### PR TITLE
Remove persistent test file by generalizing buildPkg()

### DIFF
--- a/R/export.R
+++ b/R/export.R
@@ -62,17 +62,28 @@ buildPkg <- function(pkgDir) {
     warning(paste(stdout, collapse = "\n"))
   }
 
-  # Extract the tarball name from the last line of stdout returned by `R CMD build`
-  #
-  # * building '{Package}_{Version}.tar.gz'
+  tarball <- extractTarballName(stdout)
+  return(invisible(tarball))
+}
+
+# Extract the tarball name from the last line of stdout returned by `R CMD build`
+#
+# eg
+#
+# * building '{Package}_{Version}.tar.gz'
+#
+# The format of the output string is very stable!
+# https://github.com/r-devel/r-svn/blob/2377495b7f412888abb81f7b5658bdf5e5f4c6c2/src/library/tools/R/build.R#L1252
+extractTarballName <- function(stdout) {
   regex <- "[^']*\\.tar\\.gz"
   regexMatch <- regexpr(regex, stdout[length(stdout)])
   tarball <- regmatches(stdout[length(stdout)], regexMatch)
+
   if (isEmpty(tarball)) {
-    warning("Unable to determine name of tarball when installing ", pkgDir)
+    warning("Unable to determine name of tarball after build")
   }
 
-  return(invisible(tarball))
+  return(tarball)
 }
 
 createTextFiles <- function(study, directoryname, calcOverlaps = FALSE) {

--- a/inst/tinytest/testExport.R
+++ b/inst/tinytest/testExport.R
@@ -136,6 +136,26 @@ if (at_home()) {
   file.remove(tarball)
 }
 
+expect_identical_xl(
+  OmicNavigator:::extractTarballName("* building 'ONstudyABC_0.0.0.9000.tar.gz'"),
+  "ONstudyABC_0.0.0.9000.tar.gz"
+)
+
+expect_identical_xl(
+  OmicNavigator:::extractTarballName("* building 'onepkg_NA.tar.gz'"),
+  "onepkg_NA.tar.gz"
+)
+
+expect_identical_xl(
+  OmicNavigator:::extractTarballName("* building 'OmicNavigator_1.16.0.tar.gz'"),
+  "OmicNavigator_1.16.0.tar.gz"
+)
+
+expect_warning_xl(
+  OmicNavigator:::extractTarballName(""),
+  "Unable to determine name of tarball after build"
+)
+
 # Check package metadata -------------------------------------------------------
 
 suppressMessages(installStudy(testStudyObj, library = tmplib))


### PR DESCRIPTION
Paying down some tech debt. I noticed that a test tarball file was persisting after the tests were run locally. The fix was to generalize `buildPkg()` to extract the tarball name for any package, not just an ONstudy package.