### PR TITLE
Remove repository dispatch `event-type` of `deploy-main`

### DIFF
--- a/.github/workflows/comprehensive.yml
+++ b/.github/workflows/comprehensive.yml
@@ -74,22 +74,3 @@ jobs:
       - name: Test results
         if: always()
         run: cat OmicNavigator.Rcheck/tests/tinytest.Rout*
-  deploy-main:
-    needs: check
-    if: ${{ github.repository == 'abbvie-external/OmicNavigator' && github.event_name != 'pull_request' }}
-    runs-on: ubuntu-latest
-    steps:
-      - name: Deploy main dispatch
-        uses: peter-evans/repository-dispatch@v3
-        with:
-          token: ${{ secrets.REPO_ACCESS_TOKEN }}
-          repository: abbvie-internal/OmicNavigatorCD
-          event-type: deploy-main
-          client-payload: '{
-            "repository": "${{ github.repository }}",
-            "ref": "${{ github.ref }}",
-            "sha": "${{ github.sha }}",
-            "workflow": "${{ github.workflow }}",
-            "run_id": "${{ github.run_id }}",
-            "run_number": "${{ github.run_number }}"
-          }'


### PR DESCRIPTION
We no longer deploy each push to "main" to a staging server