### PR TITLE
Remove plots from listStudies() output

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+* The output from `listStudies()` no longer includes the plots in each study.
+The app now calls `getPlots()` as needed to obtain this information.
+
 # 1.16.3
 
 * The release tarball includes version 2.0.3 of the web app

--- a/R/app.R
+++ b/R/app.R
@@ -14,7 +14,6 @@
 #'   \item{package}{(list) The fields from \code{DESCRIPTION}}
 #'   \item{results}{(nested list) The testIDs available for each modelID}
 #'   \item{enrichments}{(nested list) The annotationIDs available for each modelID}
-#'   \item{plots}{(nested list) The plotIDs available for each modelID}
 #'
 #' @export
 listStudies <- function(libraries = NULL) {
@@ -63,9 +62,26 @@ listStudies <- function(libraries = NULL) {
     }
 
     studySummary <- readJson(studySummaryFile, simplifyVector = FALSE)
-    # Remove plotting information to reduce size of return object. The app now
-    # obtains plots directly via getPlots()
+
+    # Explanation: OmicNavigator 1.16 and earlier included the plots for each
+    # study in the output of listStudies() (via exportSummary() in export.R).
+    # However, the plots were removed because 1) a new field "description" was
+    # added to addPlots()/getPlots()/WebApp but not added to listStudies(), and
+    # 2) the size of the listStudies() return object was hurting the app's
+    # performance as the number of installed study packages increased.
+    #
+    # https://github.com/abbvie-external/OmicNavigator/commit/46bb2bdf8af5042bdb66848c5b0ffb768752290b
+    # https://github.com/abbvie-external/OmicNavigatorWebApp/commit/dfb9a8797b434ac19f5ead72f398c495f75549e3
+    #
+    # Thus instead of adding "description" to listStudies(), since the app was
+    # already refactored to call getPlots(), we removed plots from listStudies()
+    # and exportSummary().
+    #
+    # To maintain backwards compatibility with study packages created with
+    # OmicNavigator 1.16 and earlier, the line below explicitly only includes
+    # the results and enrichments. This removes any plots if they exist.
     studySummary <- studySummary[c("results", "enrichments")]
+
     output[[i]] <- c(output[[i]], studySummary)
   }
 

--- a/R/app.R
+++ b/R/app.R
@@ -63,6 +63,9 @@ listStudies <- function(libraries = NULL) {
     }
 
     studySummary <- readJson(studySummaryFile, simplifyVector = FALSE)
+    # Remove plotting information to reduce size of return object. The app now
+    # obtains plots directly via getPlots()
+    studySummary <- studySummary[c("results", "enrichments")]
     output[[i]] <- c(output[[i]], studySummary)
   }
 

--- a/R/export.R
+++ b/R/export.R
@@ -328,14 +328,10 @@ exportSummary <- function(x, path = ".") {
 
   resultsModels <- names(x[["results"]])
   enrichmentsModels <- names(x[["enrichments"]])
-  # Plots can be shared across models using modelID "default". Thus need to
-  # consider all models that have inference results or enrichments available.
-  plotsModels <- unique(c(resultsModels, enrichmentsModels))
 
   output <- list(
     results = vector("list", length(resultsModels)),
-    enrichments = vector("list", length(enrichmentsModels)),
-    plots = vector("list", length(plotsModels))
+    enrichments = vector("list", length(enrichmentsModels))
   )
 
   for (i in seq_along(resultsModels)) {
@@ -384,30 +380,6 @@ exportSummary <- function(x, path = ".") {
       output[["enrichments"]][[i]][["annotations"]][[j]] <- list(
         annotationID = annotationID,
         annotationDisplay = annotationDisplay
-      )
-    }
-  }
-
-  for (i in seq_along(plotsModels)) {
-    modelID <- plotsModels[i]
-    modelDisplay <- getModels(x, modelID = modelID, quiet = TRUE)
-    if (isEmpty(modelDisplay)) modelDisplay <- modelID
-    output[["plots"]][[i]] <- list(
-      modelID = modelID,
-      modelDisplay = modelDisplay
-    )
-    modelPlots <- getPlots(x, modelID = modelID, quiet = TRUE)
-    output[["plots"]][[i]][["plots"]] <- vector("list", length(modelPlots))
-    for (j in seq_along(modelPlots)) {
-      plotID <- names(modelPlots)[j]
-      plotDisplay = modelPlots[[j]][["displayName"]]
-      if (isEmpty(plotDisplay)) plotDisplay <- plotID
-      plotType <- modelPlots[[j]][["plotType"]]
-      if (isEmpty(plotType)) plotType <- "singleFeature"
-      output[["plots"]][[i]][["plots"]][[j]] <- list(
-        plotID = plotID,
-        plotDisplay = plotDisplay,
-        plotType = plotType
       )
     }
   }

--- a/inst/tinytest/testApp.R
+++ b/inst/tinytest/testApp.R
@@ -75,7 +75,7 @@ expect_identical_xl(
 
 expect_identical_xl(
   names(studies[[1]]),
-  c("name", "package", "results", "enrichments", "plots")
+  c("name", "package", "results", "enrichments")
 )
 
 expect_identical_xl(
@@ -110,37 +110,6 @@ expect_identical_xl(
   vapply(studies[[1]][["enrichments"]][[1]][["annotations"]],
          function(x) x[["annotationID"]], character(1)),
   names(getEnrichments(testStudyObj, modelID = testModelName))
-)
-
-expect_identical_xl(
-  vapply(studies[[1]][["plots"]], function(x) x[["modelID"]], character(1)),
-  names(getModels(testStudyObj))
-)
-
-expect_identical_xl(
-  vapply(studies[[1]][["plots"]][[1]][["plots"]],
-         function(x) x[["plotID"]], character(1)),
-  names(getPlots(testStudyObj, modelID = testModelName))
-)
-
-expect_identical_xl(
-  studies[[1]][["plots"]][[1]][["plots"]][[1]][["plotType"]],
-  "singleFeature"
-)
-
-expect_identical_xl(
-  studies[[1]][["plots"]][[1]][["plots"]][[2]][["plotType"]],
-  "multiFeature"
-)
-
-expect_identical_xl(
-  studies[[1]][["plots"]][[1]][["plots"]][[3]][["plotType"]],
-  "multiTest"
-)
-
-expect_identical_xl(
-  studies[[1]][["plots"]][[1]][["plots"]][[4]][["plotType"]],
-  list("multiFeature", "multiTest")
 )
 
 # If there are no OmicNavigator study packages installed, return an empty list.

--- a/man/listStudies.Rd
+++ b/man/listStudies.Rd
@@ -20,7 +20,6 @@ study package. Each study package entry has the following sublist components:
 \item{package}{(list) The fields from \code{DESCRIPTION}}
 \item{results}{(nested list) The testIDs available for each modelID}
 \item{enrichments}{(nested list) The annotationIDs available for each modelID}
-\item{plots}{(nested list) The plotIDs available for each modelID}
 }
 \description{
 List available studies and their metadata

--- a/vignettes/OmicNavigatorAPI.Rnw
+++ b/vignettes/OmicNavigatorAPI.Rnw
@@ -91,11 +91,7 @@ local({
 \section{List studies}
 \label{sec:list-studies}
 
-List all the available studies along with their models, tests, annotations, and
-plots.
-
-\textbf{Update:} The \texttt{plotType} may be a single string or a nested list
-of multiple plot types (e.g. ``singleFeature'' and ``multiTest'')
+List all the available studies along with their models, tests, and annotations.
 
 <<list-studies, eval=FALSE>>=
 studies <- listStudies()
@@ -228,6 +224,22 @@ toJSON(linkFeatures[1:4], pretty = TRUE)
 
 \section{Custom plots}
 \label{sec:custom-plots}
+
+Obtain
+
+For a given study and model, return a list of any custom plots for that study
+with \texttt{getPlots()}.
+
+\textbf{Update:} The \texttt{plotType} may be a single string or a nested list
+of multiple plot types (e.g. ``singleFeature'' and ``multiTest'')
+
+<<getPlots>>=
+plots <- getPlots(
+  study = "ABC",
+  modelID = "model_01"
+)
+toJSON(plots, auto_unbox = TRUE, pretty = TRUE)
+@
 
 Display the custom plots provided by the user with \texttt{plotStudy()}. Provided a
 study, model, feature, test, and plot, \texttt{plotStudy()} generates the custom plot.


### PR DESCRIPTION
The web app is already calling `getPlots()`. Once it is refactored to no longer access the plots from `listStudies()`, we can merge this PR, which drastically reduces the size of the object returned by `listStudies()` when there are many installed study packages with custom plotting functions.

I can also deploy this to the dev branch for pre-testing once the app is ready.