### PR TITLE
Document optional tooltips for results table added via addTests()

### DIFF
--- a/R/add.R
+++ b/R/add.R
@@ -259,7 +259,10 @@ addAssays <- function(study, assays, reset = FALSE) {
 #'   describing the testID. To share tests across multiple models, use the
 #'   modelID "default". Instead of a single character string, you can provide a
 #'   list of metadata fields about each test. The field "description" will be
-#'   used to derive the tooltip displayed in the app.
+#'   used to derive the tooltip displayed in the app. Furthermore, any fields
+#'   that match the column names in the results table (added via
+#'   \code{\link{addFeatures}} or \code{\link{addResults}}) will be used to
+#'   derive tooltips for those columns.
 #' @inherit shared-add
 #'
 #' @examples

--- a/man/addTests.Rd
+++ b/man/addTests.Rd
@@ -16,7 +16,10 @@ names should be the testIDs. The value should be a single character string
 describing the testID. To share tests across multiple models, use the
 modelID "default". Instead of a single character string, you can provide a
 list of metadata fields about each test. The field "description" will be
-used to derive the tooltip displayed in the app.}
+used to derive the tooltip displayed in the app. Furthermore, any fields
+that match the column names in the results table (added via
+\code{\link{addFeatures}} or \code{\link{addResults}}) will be used to
+derive tooltips for those columns.}
 
 \item{reset}{Reset the data prior to adding the new data (default:
 \code{FALSE}). The default is to add to or modify any previously added data

--- a/man/createStudy.Rd
+++ b/man/createStudy.Rd
@@ -68,7 +68,10 @@ names should be the testIDs. The value should be a single character string
 describing the testID. To share tests across multiple models, use the
 modelID "default". Instead of a single character string, you can provide a
 list of metadata fields about each test. The field "description" will be
-used to derive the tooltip displayed in the app.}
+used to derive the tooltip displayed in the app. Furthermore, any fields
+that match the column names in the results table (added via
+\code{\link{addFeatures}} or \code{\link{addResults}}) will be used to
+derive tooltips for those columns.}
 
 \item{annotations}{The annotations used for the enrichment analyses. The
 input is a nested list. The top-level list contains one entry per

--- a/vignettes/OmicNavigatorAPI.Rnw
+++ b/vignettes/OmicNavigatorAPI.Rnw
@@ -146,6 +146,10 @@ nrow(resultsTableTerm)
 toJSON(resultsTableTerm[1:2, ], pretty = TRUE)
 @
 
+Optional descriptions of each column to be displayed as tooltips can be obtained
+via a call to \texttt{getTests()} with the corresponding \texttt{modelID} and
+\texttt{testID}.
+
 \section{Enrichments table}
 \label{sec:enrichments-table}
 


### PR DESCRIPTION
The app supports this feature, and we demonstrate it in OmicNavigatorExample, but it isn't officially documented.

https://github.com/abbvie-external/OmicNavigatorExample/commit/e55290e5b63438d77cd1f45d5cd4cfbdeacfcf3e
https://github.com/abbvie-external/OmicNavigatorExample/blob/06326585437160c84101f4ccf83feeea11d6288f/build.R#L76