### PR TITLE
Validate metaAssays

### DIFF
--- a/R/tests.R
+++ b/R/tests.R
@@ -34,6 +34,7 @@ testStudy <- function(name,
                        metaFeaturesLinkouts = testMetaFeaturesLinkouts(),
                        mapping = testMapping(seed = seed, nFeatures = nFeatures,
                                              numericFeatureID = numericFeatureID),
+                       metaAssays = testMetaAssays(),
                        version = version,
                        maintainer = maintainer,
                        maintainerEmail = maintainerEmail,
@@ -479,6 +480,25 @@ testMetaFeaturesLinkouts <- function(n = 3) {
     )
   )
   return(metaFeaturesLinkouts)
+}
+
+# Like testMetaFeatures(), assigns 3 metaFeatures to each feature
+testMetaAssays <- function(n = 3, rows = 100, cols = 10, seed = 12345L) {
+  set.seed(seed)
+  metaAssays <- vector(mode = "list", length = n)
+  names(metaAssays) <- sprintf("model_%02d", seq_len(n))
+  metaFeatureID <- sprintf("metaFeature_%04d", seq_len(rows * 3))
+  sampleID <- sprintf("sample_%04d", seq_len(cols))
+  for (i in seq_len(n)) {
+    metaAssays[[i]] <- matrix(
+      sample(seq(-2, 2, by = 0.0001), size = rows * 3 * cols, replace = TRUE),
+      nrow = rows * 3, ncol = cols
+    )
+    rownames(metaAssays[[i]]) <- metaFeatureID
+    colnames(metaAssays[[i]]) <- sampleID
+    metaAssays[[i]] <- as.data.frame(metaAssays[[i]])
+  }
+  return(metaAssays)
 }
 
 testStudyMeta <- function() {

--- a/inst/tinytest/testAdd.R
+++ b/inst/tinytest/testAdd.R
@@ -60,6 +60,9 @@ study <- addEnrichmentsLinkouts(study, enrichmentsLinkouts = enrichmentsLinkouts
 metaFeaturesLinkouts <- OmicNavigator:::testMetaFeaturesLinkouts()
 study <- addMetaFeaturesLinkouts(study, metaFeaturesLinkouts = metaFeaturesLinkouts)
 
+metaAssays <- OmicNavigator:::testMetaAssays()
+study <- addMetaAssays(study, metaAssays = metaAssays)
+
 expect_identical_xl(
   study,
   OmicNavigator:::testStudy(name = "test")

--- a/inst/tinytest/testPlot.R
+++ b/inst/tinytest/testPlot.R
@@ -351,7 +351,7 @@ expect_true_xl(
 
 expect_identical_xl(
   names(plottingData),
-  c("assays", "samples", "features")
+  c("assays", "samples", "features", "metaFeatures", "metaAssays")
 )
 
 expect_true_xl(
@@ -381,6 +381,20 @@ expect_equal_xl(
   features[features[[1]] == "feature_0001", ]
 )
 
+# Without MetaAssays, only assays/samples/features are returned
+testStudyObjNoMetaAssays <- testStudyObj
+testStudyObjNoMetaAssays[["metaAssays"]] <- list()
+plottingDataNoMetaAssays <- getPlottingData(
+  testStudyObjNoMetaAssays,
+  modelID = testModelName,
+  featureID = "feature_0001"
+)
+
+expect_identical_xl(
+  names(plottingDataNoMetaAssays),
+  c("assays", "samples", "features")
+)
+
 # getPlottingData (package) ----------------------------------------------------
 
 plottingData <- getPlottingData(
@@ -395,7 +409,7 @@ expect_true_xl(
 
 expect_identical_xl(
   names(plottingData),
-  c("assays", "samples", "features")
+  c("assays", "samples", "features", "metaFeatures", "metaAssays")
 )
 
 expect_true_xl(
@@ -439,7 +453,7 @@ expect_true_xl(
 
 expect_identical_xl(
   names(plottingData),
-  c("assays", "samples", "features")
+  c("assays", "samples", "features", "metaFeatures", "metaAssays")
 )
 
 expect_true_xl(
@@ -818,7 +832,7 @@ expect_true_xl(
 
 expect_identical_xl(
   names(plottingData),
-  c("assays", "samples", "features", "results")
+  c("assays", "samples", "features", "results", "metaFeatures", "metaAssays")
 )
 
 expect_true_xl(
@@ -872,7 +886,7 @@ expect_true_xl(
 
 expect_identical_xl(
   names(plottingData),
-  c("assays", "samples", "features", "results")
+  c("assays", "samples", "features", "results", "metaFeatures", "metaAssays")
 )
 
 expect_true_xl(
@@ -926,7 +940,7 @@ expect_true_xl(
 
 expect_identical_xl(
   names(plottingData),
-  c("assays", "samples", "features", "results")
+  c("assays", "samples", "features", "results", "metaFeatures", "metaAssays")
 )
 
 expect_true_xl(

--- a/inst/tinytest/testValidate.R
+++ b/inst/tinytest/testValidate.R
@@ -274,3 +274,39 @@ expect_error_xl(
   validateStudy(invalidMapping),
   "Mapping features for modelID do not match features from modelID results table\n"
 )
+
+# metaAssays -----------------------------------------------------------------------
+
+# Column names should match sampleIDs
+invalidMetaAssaysCols <- testStudyObj
+colnames(invalidMetaAssaysCols[["metaAssays"]][[1]])[1] <- "non-existent"
+
+expect_message_xl(
+  validateStudy(invalidMetaAssaysCols),
+  "Some of the sampleIDs in the samples table are missing from the columns in the metaAssays table"
+)
+
+colnames(invalidMetaAssaysCols[["metaAssays"]][[1]]) <-
+  sprintf("overwrite-all-colnames-%d", seq_along(invalidMetaAssaysCols[["metaAssays"]][[1]]))
+
+expect_error_xl(
+  validateStudy(invalidMetaAssaysCols),
+  "The sampleIDs in the samples table do not match the column names in the metaAssays table"
+)
+
+# Row names should match metaFeatureIDs
+invalidMetaAssaysRows <- testStudyObj
+rownames(invalidMetaAssaysRows[["metaAssays"]][[1]])[1] <- "non-existent"
+
+expect_message_xl(
+  validateStudy(invalidMetaAssaysRows),
+  "Some of the metaFeatureIDs in the metaFeatures table are missing from the rows in the metaAssays table"
+)
+
+rownames(invalidMetaAssaysRows[["metaAssays"]][[1]]) <-
+  sprintf("overwrite-all-rownames-%d", seq_len(nrow(invalidMetaAssaysRows[["metaAssays"]][[1]])))
+
+expect_error_xl(
+  validateStudy(invalidMetaAssaysRows),
+  "The metaFeatureIDs in the metaFeatures table do not match the row names in the metaAssays table"
+)


### PR DESCRIPTION
Adds `validateMetaAssays()` which validates the following:

* The row names of the metaAssays data frame should match the metaFeatureIDs of the metaFeatures data frame (2nd column)
* The column names of the metaAssays data frame should match the sampleIDs of the samples data frame (first column)

If there is only partial agreement, a message is printed to the console. An error is only thrown if there is a complete mismatch, indicating a user mistake or misunderstanding.

To facilitate testing, also created `testMetaAssays()`

While preparing this PR, I noticed and fixed a few other things, which I pushed directly to main:

* Improve tests for validation of metaFeatures (https://github.com/abbvie-external/OmicNavigator/commit/3bbe563f05ecae7cdacaa3e3ef9b54544e9c9ea2)
* Sort the metaFeatures/metaAssays from getPlottingData() for multiFeature plots (https://github.com/abbvie-external/OmicNavigator/commit/caf6fb56c530863eb2caf2ecc02af55709b0a516)