### PR TITLE
Support exporting studies without a results table

### DIFF
--- a/R/validate.R
+++ b/R/validate.R
@@ -33,7 +33,7 @@ validateResults <- function(study) {
   results <- study[["results"]]
 
   if (isEmpty(results)) {
-    stop("No results. A valid study requires at least one results table. Use addResults() to add one.")
+    warning("No results. The Differential tab in the app requires at least one results table. Use addResults() to add one.")
   }
 
   for (i in seq_along(results)) {

--- a/inst/tinytest/testExport.R
+++ b/inst/tinytest/testExport.R
@@ -313,6 +313,31 @@ expect_error_xl(
   'The plot "sharedPlot" is not available.'
 )
 
+# Minimal study ----------------------------------------------------------------
+
+emptyStudy <- createStudy(name = "empty")
+
+expect_warning_xl(
+  exportStudy(emptyStudy, type = "package", path = tempdir()),
+  "No results"
+)
+
+expect_true_xl(
+  dir.exists(file.path(tempdir(), "ONstudyempty/inst/OmicNavigator/"))
+)
+
+assaysOnly <- createStudy(name = "assaysOnly")
+assaysOnly <- addAssays(assaysOnly, OmicNavigator:::testAssays())
+
+expect_warning_xl(
+  exportStudy(assaysOnly, type = "package", path = tempdir()),
+  "No results"
+)
+
+expect_true_xl(
+  dir.exists(file.path(tempdir(), "ONstudyassaysOnly/inst/OmicNavigator/assays"))
+)
+
 # Teardown ---------------------------------------------------------------------
 
 # todo: plotStudy() should unload study package namespace if it wasn't already loaded

--- a/inst/tinytest/testExport.R
+++ b/inst/tinytest/testExport.R
@@ -315,10 +315,10 @@ expect_error_xl(
 
 # Minimal study ----------------------------------------------------------------
 
-emptyStudy <- createStudy(name = "empty")
+emptyStudyObj <- createStudy(name = "empty")
 
 expect_warning_xl(
-  exportStudy(emptyStudy, type = "package", path = tempdir()),
+  exportStudy(emptyStudyObj, type = "package", path = tempdir()),
   "No results"
 )
 

--- a/inst/tinytest/testGet.R
+++ b/inst/tinytest/testGet.R
@@ -24,7 +24,7 @@ libOrig <- .libPaths()
 suppressMessages(installStudy(testStudyObj))
 suppressMessages(installStudy(minimalStudyObj))
 
-emptyStudy <- createStudy(name = "empty")
+emptyStudyObj <- createStudy(name = "empty")
 
 # installedStudies -------------------------------------------------------------
 
@@ -101,7 +101,7 @@ expect_identical_xl(
 )
 
 expect_message_xl(
-  getSamples(emptyStudy),
+  getSamples(emptyStudyObj),
   "No samples available"
 )
 
@@ -153,7 +153,7 @@ expect_identical_xl(
 )
 
 expect_message_xl(
-  getFeatures(emptyStudy),
+  getFeatures(emptyStudyObj),
   "No features available"
 )
 
@@ -195,7 +195,7 @@ expect_message_xl(
 )
 
 expect_message_xl(
-  getAssays(emptyStudy),
+  getAssays(emptyStudyObj),
   "No assays available"
 )
 
@@ -237,7 +237,7 @@ expect_message_xl(
 )
 
 expect_message_xl(
-  getModels(emptyStudy),
+  getModels(emptyStudyObj),
   "No models available"
 )
 
@@ -289,7 +289,7 @@ expect_error_xl(
 )
 
 expect_message_xl(
-  getTests(emptyStudy),
+  getTests(emptyStudyObj),
   "No tests available"
 )
 
@@ -321,7 +321,7 @@ expect_identical_xl(
 )
 
 expect_message_xl(
-  getAnnotations(emptyStudy),
+  getAnnotations(emptyStudyObj),
   "No annotations available"
 )
 
@@ -363,7 +363,7 @@ expect_error_xl(
 )
 
 expect_message_xl(
-  getResults(emptyStudy),
+  getResults(emptyStudyObj),
   "No results available"
 )
 
@@ -460,7 +460,7 @@ expect_error_xl(
 )
 
 expect_message_xl(
-  getEnrichments(emptyStudy),
+  getEnrichments(emptyStudyObj),
   "No enrichments available"
 )
 
@@ -567,7 +567,7 @@ expect_identical_xl(
 )
 
 expect_message_xl(
-  getMetaFeatures(emptyStudy),
+  getMetaFeatures(emptyStudyObj),
   "No metaFeatures available"
 )
 
@@ -594,7 +594,7 @@ expect_identical_xl(
 )
 
 expect_message_xl(
-  getPlots(emptyStudy),
+  getPlots(emptyStudyObj),
   "No plots available"
 )
 
@@ -631,7 +631,7 @@ expect_identical_xl(
 )
 
 expect_message_xl(
-  getMapping(emptyStudy),
+  getMapping(emptyStudyObj),
   "No mapping available"
 )
 
@@ -664,7 +664,7 @@ expect_identical_xl(
 )
 
 expect_message_xl(
-  getBarcodes(emptyStudy),
+  getBarcodes(emptyStudyObj),
   "No barcodes available"
 )
 
@@ -708,7 +708,7 @@ expect_identical_xl(
 )
 
 expect_message_xl(
-  getReports(emptyStudy),
+  getReports(emptyStudyObj),
   "No reports available"
 )
 
@@ -747,7 +747,7 @@ expect_identical_xl(
 )
 
 expect_message_xl(
-  getResultsLinkouts(emptyStudy),
+  getResultsLinkouts(emptyStudyObj),
   "No resultsLinkouts available"
 )
 
@@ -786,7 +786,7 @@ expect_identical_xl(
 )
 
 expect_message_xl(
-  getEnrichmentsLinkouts(emptyStudy),
+  getEnrichmentsLinkouts(emptyStudyObj),
   "No enrichmentsLinkouts available"
 )
 
@@ -825,7 +825,7 @@ expect_identical_xl(
 )
 
 expect_message_xl(
-  getMetaFeaturesLinkouts(emptyStudy),
+  getMetaFeaturesLinkouts(emptyStudyObj),
   "No metaFeaturesLinkouts available"
 )
 

--- a/inst/tinytest/testImport.R
+++ b/inst/tinytest/testImport.R
@@ -22,12 +22,21 @@ testAnnotationName <- names(testStudyObj[["annotations"]])[1]
 minimalStudyObj <- OmicNavigator:::testStudyMinimal()
 minimalStudyName <- minimalStudyObj[["name"]]
 
+emptyStudyObj <- createStudy(name = "empty", description = "An empty study")
+emptyStudyName <- emptyStudyObj[["name"]]
+
+assaysOnlyStudyObj <- createStudy(name = "assaysOnly", description = "A study with only assays")
+assaysOnlyStudyName <- assaysOnlyStudyObj[["name"]]
+assaysOnlyStudyObj <- addAssays(assaysOnlyStudyObj, OmicNavigator:::testAssays())
+
 tmplib <- tempfile()
 dir.create(tmplib)
 libOrig <- .libPaths()
 .libPaths(c(tmplib, libOrig))
 suppressMessages(installStudy(testStudyObj))
 suppressMessages(installStudy(minimalStudyObj))
+suppressMessages(installStudy(emptyStudyObj))
+suppressMessages(installStudy(assaysOnlyStudyObj))
 
 # importStudy ------------------------------------------------------------------
 
@@ -233,6 +242,27 @@ expect_identical_xl(
 expect_identical_xl(
   importedMinimal[["maintainerEmail"]],
   "unknown@unknown"
+)
+
+# importStudy - empty ----------------------------------------------------------
+
+importedEmpty <- importStudy(emptyStudyName)
+
+# These elements are assigned a default value on export
+elementsWithDefaults <- c("version", "maintainer", "maintainerEmail", "studyMeta")
+
+expect_identical_xl(
+  importedEmpty[!names(importedEmpty) %in% elementsWithDefaults],
+  emptyStudyObj[!names(emptyStudyObj) %in% elementsWithDefaults]
+)
+
+# importStudy - assays only ----------------------------------------------------
+
+importedAssaysOnly <- importStudy(assaysOnlyStudyName)
+
+expect_equal_xl(
+  importedAssaysOnly[["assays"]],
+  assaysOnlyStudyObj[["assays"]]
 )
 
 # Teardown ---------------------------------------------------------------------

--- a/inst/tinytest/testPrint.R
+++ b/inst/tinytest/testPrint.R
@@ -7,19 +7,19 @@ using(ttdo)
 
 library(OmicNavigator)
 
-emptyStudy <- createStudy(name = "empty", description = "An empty study")
-testStudy <- OmicNavigator:::testStudy(name = "test", description = "A test study")
-testStudyPlots <- addPlots(testStudy, OmicNavigator:::testPlots())
+emptyStudyObj <- createStudy(name = "empty", description = "An empty study")
+testStudyObj <- OmicNavigator:::testStudy(name = "test", description = "A test study")
+testStudyPlots <- addPlots(testStudyObj, OmicNavigator:::testPlots())
 
 # Test print.onStudy() ---------------------------------------------------------
 
 expect_stdout(
-  print(emptyStudy),
+  print(emptyStudyObj),
   "0 models"
 )
 
 expect_stdout(
-  print(testStudy),
+  print(testStudyObj),
   "3 models"
 )
 

--- a/inst/tinytest/testSummary.R
+++ b/inst/tinytest/testSummary.R
@@ -7,19 +7,19 @@ using(ttdo)
 
 library(OmicNavigator)
 
-emptyStudy <- createStudy(name = "empty", description = "An empty study")
-testStudy <- OmicNavigator:::testStudy(name = "test", description = "A test study")
-testStudyPlots <- addPlots(testStudy, OmicNavigator:::testPlots())
+emptyStudyObj <- createStudy(name = "empty", description = "An empty study")
+testStudyObj <- OmicNavigator:::testStudy(name = "test", description = "A test study")
+testStudyPlots <- addPlots(testStudyObj, OmicNavigator:::testPlots())
 
 # Test summary.onStudy() -------------------------------------------------------
 
 expect_stdout(
-  summary(emptyStudy),
+  summary(emptyStudyObj),
   "empty"
 )
 
 expect_stdout(
-  summary(testStudy),
+  summary(testStudyObj),
   "\\|-reports \\(2\\)"
 )
 

--- a/inst/tinytest/testValidate.R
+++ b/inst/tinytest/testValidate.R
@@ -12,7 +12,7 @@ testStudyName <- "ABC"
 testStudyObj <- OmicNavigator:::testStudy(name = testStudyName, version = "0.3")
 testStudyObj <- addPlots(testStudyObj, OmicNavigator:::testPlots())
 minimalStudyObj <- OmicNavigator:::testStudyMinimal()
-emptyStudy <- createStudy(name = "empty", description = "An empty study")
+emptyStudyObj <- createStudy(name = "empty", description = "An empty study")
 
 # Results ----------------------------------------------------------------------
 
@@ -27,7 +27,7 @@ expect_true_xl(
 )
 
 expect_warning_xl(
-  validateStudy(emptyStudy),
+  validateStudy(emptyStudyObj),
   "No results",
   info = "The Differential tab in the app requires at least one results table"
 )

--- a/inst/tinytest/testValidate.R
+++ b/inst/tinytest/testValidate.R
@@ -26,10 +26,10 @@ expect_true_xl(
   info = "A minimal study should pass"
 )
 
-expect_error_xl(
+expect_warning_xl(
   validateStudy(emptyStudy),
   "No results",
-  info = "A valid study requires at least one results table"
+  info = "The Differential tab in the app requires at least one results table"
 )
 
 # Throw warning if no common columns across tests of a model

--- a/vignettes/OmicNavigatorUsersGuide.Rnw
+++ b/vignettes/OmicNavigatorUsersGuide.Rnw
@@ -397,10 +397,11 @@ For more details, run \texttt{?addResults}.
 % does exactly what I wanted.
 % https://en.wikibooks.org/wiki/LaTeX/Boxes#framebox_and_fbox
 \begin{framed}
-\textbf{Important:} You can stop here! The minimal required data for a valid
-OmicNavigator study is a single results table. Any additional data you add enables
-more features in the app for exploring your study. See Section \ref{sec:mapping}
-for the mapping between data elements and app features.
+\textbf{Important:} You can stop here! With only a single results table, you can
+already start using the app to interactively investigate your study. Any
+additional data you add enables more features in the app for further
+exploration. See Section \ref{sec:mapping} for the mapping between data elements
+and app features.
 \end{framed}
 
 \subsection{Enrichments}


### PR DESCRIPTION
If a study does not have a results table, `validateStudy()` now throws a warning instead of an error. This enables users to export a study with other data, eg assays.

The app already gracefully handles this situation. If a study with no results table is selected in the Differential tab, then the model dropdown simply lists no available options.

<img width="1306" height="613" alt="image" src="https://github.com/user-attachments/assets/82241384-60d2-4540-b9cf-22883f19633c" />



xref: #72