### PR TITLE
Do not pass duplicate key columns to as.data.table()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -59,5 +59,5 @@ Suggests:
   tinytest (>= 1.2.3),
   ttdo (>= 0.0.6),
   UpSetR
-RoxygenNote: 7.3.3
+Config/roxygen2/version: 8.0.0
 Roxygen: list(markdown = TRUE)

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -59,5 +59,5 @@ Suggests:
   tinytest (>= 1.2.3),
   ttdo (>= 0.0.6),
   UpSetR
-Config/roxygen2/version: 8.0.0
+Config/roxygen2/version: 8.1.0
 Roxygen: list(markdown = TRUE)

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -11,7 +11,7 @@ Description:
   deployed online to be explored by collaborators. The dashboard includes
   'sortable' tables, interactive plots including network visualization, and
   fine-grained filtering based on statistical significance.
-Version: 1.19.3
+Version: 1.19.4
 Authors@R: c(
   person("Terrence", "Ernst", role = c("aut"),
          comment = "Web application"),

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -79,43 +79,53 @@ export(plotStudy)
 export(removeStudy)
 export(startApp)
 export(validateStudy)
-importFrom(data.table,"%chin%")
-importFrom(data.table,":=")
-importFrom(data.table,.N)
-importFrom(data.table,as.data.table)
-importFrom(data.table,chmatch)
-importFrom(data.table,data.table)
-importFrom(data.table,dcast.data.table)
-importFrom(data.table,fread)
-importFrom(data.table,fwrite)
-importFrom(data.table,melt)
-importFrom(data.table,merge.data.table)
-importFrom(data.table,setDF)
-importFrom(data.table,setDT)
-importFrom(data.table,setcolorder)
-importFrom(data.table,setnames)
-importFrom(data.table,setorderv)
-importFrom(graphics,barplot)
-importFrom(graphics,par)
-importFrom(graphics,plot)
-importFrom(graphics,text)
-importFrom(jsonlite,read_json)
-importFrom(jsonlite,write_json)
-importFrom(stats,median)
-importFrom(stats,pnorm)
-importFrom(stats,prcomp)
-importFrom(stats,rnorm)
-importFrom(stats,runif)
-importFrom(stats,setNames)
+importFrom(data.table,
+  "%chin%",
+  ":=",
+  .N,
+  as.data.table,
+  chmatch,
+  data.table,
+  dcast.data.table,
+  fread,
+  fwrite,
+  melt,
+  merge.data.table,
+  setDF,
+  setDT,
+  setcolorder,
+  setnames,
+  setorderv
+)
+importFrom(graphics,
+  barplot,
+  par,
+  plot,
+  text
+)
+importFrom(jsonlite,
+  read_json,
+  write_json
+)
+importFrom(stats,
+  median,
+  pnorm,
+  prcomp,
+  rnorm,
+  runif,
+  setNames
+)
 importFrom(tools,file_ext)
-importFrom(utils,capture.output)
-importFrom(utils,download.file)
-importFrom(utils,getFromNamespace)
-importFrom(utils,head)
-importFrom(utils,install.packages)
-importFrom(utils,installed.packages)
-importFrom(utils,modifyList)
-importFrom(utils,packageDescription)
-importFrom(utils,packageVersion)
-importFrom(utils,remove.packages)
-importFrom(utils,unzip)
+importFrom(utils,
+  capture.output,
+  download.file,
+  getFromNamespace,
+  head,
+  install.packages,
+  installed.packages,
+  modifyList,
+  packageDescription,
+  packageVersion,
+  remove.packages,
+  unzip
+)

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,10 @@
+# 1.19.4
+
+* Do not pass duplicate key columns to `as.data.table()`. This prevents an
+error in `getResultsUpset()` identified in a reverse dependency check for the
+development version of {data.table}. The results returned by `getResultsUpset()`
+are unchanged.
+
 # 1.19.3
 
 * The release tarball includes version 2.3.3 of the web app

--- a/R/upset.R
+++ b/R/upset.R
@@ -375,7 +375,7 @@ getResultsUpset <- function(
   }
 
   # Convert to keyed data tables
-  toDataTable <- function(x) as.data.table(x, key = column)
+  toDataTable <- function(x) as.data.table(x, key = unique(column))
   resultsDt <- Map(toDataTable, results)
 
   # Filter rows. First construct the filtering expression as a character, and

--- a/inst/tinytest/testUpset.R
+++ b/inst/tinytest/testUpset.R
@@ -635,11 +635,52 @@ expect_error_xl(
   getResultsUpset(
     study = testStudyName,
     modelID = testModelName,
-    sigValue = c(0, 0),
-    operator = c("<", ">"),
-    column = c("beta", "beta")
+    sigValue = 500,
+    operator = ">",
+    column = "beta"
   ),
   "There were no features remaining after applying the filters."
+)
+
+# Support multiple filters using the same column
+sameColumnResultsTest01 <- getResultsIntersection(
+  study = testStudyObj,
+  modelID = testModelName,
+  anchor = "test_01",
+  mustTests = c(),
+  notTests = c(),
+  sigValue = c(-1, 1),
+  operator = c(">", "<"),
+  column = c("beta", "beta")
+)
+
+sameColumnResultsTest02 <- getResultsIntersection(
+  study = testStudyObj,
+  modelID = testModelName,
+  anchor = "test_02",
+  mustTests = c(),
+  notTests = c(),
+  sigValue = c(-1, 1),
+  operator = c(">", "<"),
+  column = c("beta", "beta")
+)
+
+sameColumnResultsUpset <- getResultsUpset(
+  study = testStudyName,
+  modelID = testModelName,
+  sigValue = c(-1, 1),
+  operator = c(">", "<"),
+  column = c("beta", "beta")
+)
+
+expect_equal_xl(
+  sum(sameColumnResultsUpset[["New_data"]][["test_01"]]),
+  nrow(sameColumnResultsTest01)
+)
+
+expect_equal_xl(
+  sum(sameColumnResultsUpset[["New_data"]][["test_02"]]),
+  nrow(sameColumnResultsTest02)
 )
 
 # Results table with differing number of features
@@ -730,7 +771,6 @@ expect_equal_xl(
   sum(resultsUpsetAbsTwo[["New_data"]][["test_01"]] & resultsUpsetAbsTwo[["New_data"]][["test_01"]]),
   sum(resultsUpsetAbsTwoLegacy[["New_data"]][["test_01"]] & resultsUpsetAbsTwoLegacy[["New_data"]][["test_01"]])
 )
-
 
 # getEnrichmentsUpset ----------------------------------------------------------
 

--- a/man/OmicNavigator-package.Rd
+++ b/man/OmicNavigator-package.Rd
@@ -42,6 +42,7 @@ Useful links:
 
 Authors:
 \itemize{
+  \item Brett Engelmann \email{brett.engelmann@abbvie.com}
   \item Terrence Ernst (Web application)
   \item John Blischak \email{jdblischak@gmail.com} (\href{https://orcid.org/0000-0003-2634-9879}{ORCID})
   \item Paul Nordlund (Web application)


### PR DESCRIPTION
This is a minor PR to fix a test failure identified in a reverse dependency check with the development version of {data.table}. We need to get this fix on CRAN to unblock the next release of {data.table}. The good news is that the results from our package are unchanged by this development.

xref: https://github.com/Rdatatable/data.table/pull/7760, https://github.com/Rdatatable/data.table/issues/7665#issuecomment-5257222998

@bengalengel After you approve and squash and merge, you will need to [create and push the tag](https://github.com/abbvie-external/OmicNavigator/blob/main/CONTRIBUTING.md#tag-a-new-release), which will auto-create the next release.

```sh
git checkout main
git pull

# confirm it is the latest commit
git log -n 1

git tag -a v1.19.4 -m "v1.19.4"
git push origin --tags
```

Once that succeeds, please [build the tarball and submit to CRAN](https://github.com/abbvie-external/OmicNavigator/blob/main/CONTRIBUTING.md#cran-submission).